### PR TITLE
Create course landing page

### DIFF
--- a/courses/ai-onboarding/builds/index.html
+++ b/courses/ai-onboarding/builds/index.html
@@ -1,0 +1,371 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>AI Onboarding: A Course for Humans | SOPs Nobody Reads</title>
+<style>
+/* ============================================
+   SOPs Nobody Reads — Course Landing Page
+   Aesthetic: 1960s Driver's Ed / Educational Film
+   Using same design system as module players
+   ============================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Playfair+Display:ital,wght@0,400;0,700;0,900;1,400&family=Source+Serif+4:ital,wght@0,300;0,400;0,600;1,300;1,400&family=DM+Sans:wght@400;500;600&display=swap');
+
+:root {
+  --bg-dark: #1a1812;
+  --bg-card: #2a2620;
+  --bg-warm: #332e26;
+  --cream: #f0e8d8;
+  --cream-dim: #c8bfad;
+  --olive: #5c6b4f;
+  --olive-light: #7a8c6a;
+  --rust: #b8704a;
+  --rust-light: #d4956a;
+  --gold: #c9a84c;
+  --gold-dim: #8a7535;
+  --red-dim: #8b3a3a;
+  --green-dim: #4a6b4a;
+  --charcoal: #3a3632;
+  --font-display: 'Playfair Display', Georgia, serif;
+  --font-body: 'Source Serif 4', Georgia, serif;
+  --font-ui: 'DM Sans', 'Segoe UI', sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  height: 100%;
+  background: var(--bg-dark);
+  color: var(--cream);
+  font-family: var(--font-body);
+}
+
+.grain {
+  position: fixed;
+  top: -50%; left: -50%;
+  width: 200%; height: 200%;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: 0.035;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  animation: grainShift 0.5s steps(4) infinite;
+}
+@keyframes grainShift {
+  0% { transform: translate(0, 0); }
+  25% { transform: translate(-2%, -1%); }
+  50% { transform: translate(1%, 2%); }
+  75% { transform: translate(-1%, -2%); }
+  100% { transform: translate(2%, 1%); }
+}
+
+.vignette {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9998;
+  background: radial-gradient(ellipse at center, transparent 50%, rgba(10,8,4,0.6) 100%);
+}
+
+.container {
+  position: relative;
+  min-height: 100vh;
+  padding: 8vh 6vw 6vh 6vw;
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.header {
+  text-align: center;
+  margin-bottom: 8vh;
+}
+
+.course-label {
+  font-family: var(--font-ui);
+  font-size: clamp(0.7rem, 1.2vw, 0.9rem);
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: var(--gold);
+  margin-bottom: 2vh;
+}
+
+.course-title {
+  font-family: var(--font-display);
+  font-size: clamp(2.5rem, 6vw, 5rem);
+  font-weight: 900;
+  line-height: 1.1;
+  color: var(--cream);
+  margin-bottom: 3vh;
+}
+
+.course-description {
+  font-family: var(--font-body);
+  font-size: clamp(1rem, 1.8vw, 1.4rem);
+  line-height: 1.6;
+  color: var(--cream-dim);
+  font-weight: 300;
+  max-width: 60ch;
+  margin: 0 auto 1vh;
+}
+
+.course-meta {
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+  color: var(--gold-dim);
+  letter-spacing: 0.1em;
+}
+
+.modules-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(350px, 1fr));
+  gap: 3vh 3vw;
+  margin-bottom: 8vh;
+}
+
+.module-card {
+  background: rgba(42,38,32,0.7);
+  border: 1px solid rgba(240,232,216,0.08);
+  border-radius: 6px;
+  padding: 4vh 3vw;
+  transition: all 0.3s ease;
+  position: relative;
+  backdrop-filter: blur(4px);
+}
+
+.module-card:hover {
+  border-color: rgba(240,232,216,0.2);
+  background: rgba(42,38,32,0.9);
+  transform: translateY(-2px);
+  box-shadow: 0 8px 32px rgba(0,0,0,0.3);
+}
+
+.module-card.available {
+  cursor: pointer;
+}
+
+.module-card.available:hover {
+  border-color: var(--gold);
+  box-shadow: 0 8px 32px rgba(201,168,76,0.15);
+}
+
+.module-card.unavailable {
+  opacity: 0.6;
+}
+
+.module-number {
+  font-family: var(--font-display);
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--gold);
+  margin-bottom: 1vh;
+}
+
+.module-title {
+  font-family: var(--font-display);
+  font-size: clamp(1.2rem, 2.2vw, 1.6rem);
+  font-weight: 700;
+  color: var(--cream);
+  line-height: 1.3;
+  margin-bottom: 1.5vh;
+}
+
+.module-part {
+  font-family: var(--font-ui);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--rust-light);
+  margin-bottom: 2vh;
+}
+
+.module-status {
+  position: absolute;
+  top: 2vh;
+  right: 3vw;
+  font-family: var(--font-ui);
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  padding: 0.5vh 1vw;
+  border-radius: 3px;
+  font-weight: 600;
+}
+
+.module-status.complete {
+  background: rgba(74,107,74,0.2);
+  color: var(--olive-light);
+  border: 1px solid var(--olive-light);
+}
+
+.module-status.available {
+  background: rgba(201,168,76,0.2);
+  color: var(--gold);
+  border: 1px solid var(--gold);
+}
+
+.module-status.coming-soon {
+  background: rgba(200,191,173,0.1);
+  color: var(--cream-dim);
+  border: 1px solid rgba(200,191,173,0.3);
+}
+
+.progress-section {
+  text-align: center;
+  margin-bottom: 6vh;
+  padding: 4vh 0;
+  border-top: 1px solid rgba(240,232,216,0.08);
+  border-bottom: 1px solid rgba(240,232,216,0.08);
+}
+
+.progress-label {
+  font-family: var(--font-ui);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--gold);
+  margin-bottom: 2vh;
+}
+
+.progress-stats {
+  font-family: var(--font-display);
+  font-size: clamp(1.5rem, 3vw, 2.4rem);
+  font-weight: 700;
+  color: var(--cream);
+  margin-bottom: 1vh;
+}
+
+.progress-detail {
+  font-family: var(--font-body);
+  font-size: 0.95rem;
+  color: var(--cream-dim);
+  font-weight: 300;
+}
+
+.brand-footer {
+  text-align: center;
+  padding-top: 4vh;
+  border-top: 1px solid rgba(240,232,216,0.06);
+}
+
+.brand-line {
+  font-family: var(--font-ui);
+  font-size: 0.7rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--gold-dim);
+}
+
+/* Scanline overlay */
+.container::after {
+  content: '';
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 3;
+  background: repeating-linear-gradient(
+    0deg,
+    transparent,
+    transparent 2px,
+    rgba(0,0,0,0.015) 2px,
+    rgba(0,0,0,0.015) 4px
+  );
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding: 4vh 4vw;
+  }
+  
+  .modules-grid {
+    grid-template-columns: 1fr;
+    gap: 2.5vh;
+  }
+  
+  .module-card {
+    padding: 3vh 4vw;
+  }
+  
+  .module-status {
+    position: relative;
+    top: auto;
+    right: auto;
+    display: inline-block;
+    margin-bottom: 1vh;
+  }
+}
+</style>
+</head>
+<body>
+
+<div class="grain"></div>
+<div class="vignette"></div>
+
+<div class="container">
+  <header class="header">
+    <div class="course-label">Professional Development</div>
+    <h1 class="course-title">AI Onboarding:<br>A Course for Humans</h1>
+    <p class="course-description">
+      A 6-module course teaching employees how to work effectively with AI tools. 
+      Learn what AI actually is, why the usual approaches fail, and how to build productive workflows that leverage these powerful but alien systems.
+    </p>
+    <div class="course-meta">6 modules • Self-paced • Professional certification</div>
+  </header>
+
+  <div class="progress-section">
+    <div class="progress-label">Course Progress</div>
+    <div class="progress-stats">2 of 6 modules available</div>
+    <div class="progress-detail">Additional modules released as development completes</div>
+  </div>
+
+  <main class="modules-grid">
+    <article class="module-card available" onclick="window.location.href='module-01/index.html'">
+      <div class="module-status complete">Complete</div>
+      <div class="module-number">Module 1</div>
+      <h2 class="module-title">You've Used AI Before (You Just Didn't Know It)</h2>
+      <div class="module-part">Part One — Know Thy Machine</div>
+    </article>
+
+    <article class="module-card available" onclick="window.location.href='module-02/index.html'">
+      <div class="module-status available">Available</div>
+      <div class="module-number">Module 2</div>
+      <h2 class="module-title">The Ghost in the Machine (There Isn't One)</h2>
+      <div class="module-part">Part One — Know Thy Machine</div>
+    </article>
+
+    <article class="module-card unavailable">
+      <div class="module-status coming-soon">Coming Soon</div>
+      <div class="module-number">Module 3</div>
+      <h2 class="module-title">How It Actually Works (The 2-Minute Version)</h2>
+      <div class="module-part">Part Two — The Prerequisites Nobody Mentions</div>
+    </article>
+
+    <article class="module-card unavailable">
+      <div class="module-status coming-soon">Coming Soon</div>
+      <div class="module-number">Module 4</div>
+      <h2 class="module-title">The Real Problem Is You (And That's Good News)</h2>
+      <div class="module-part">Part Two — The Prerequisites Nobody Mentions</div>
+    </article>
+
+    <article class="module-card unavailable">
+      <div class="module-status coming-soon">Coming Soon</div>
+      <div class="module-number">Module 5</div>
+      <h2 class="module-title">The Prompt Is the Product</h2>
+      <div class="module-part">Part Three — The Technical Layer</div>
+    </article>
+
+    <article class="module-card unavailable">
+      <div class="module-status coming-soon">Coming Soon</div>
+      <div class="module-number">Module 6</div>
+      <h2 class="module-title">The Rules of the Road</h2>
+      <div class="module-part">Part Three — The Technical Layer</div>
+    </article>
+  </main>
+
+  <footer class="brand-footer">
+    <div class="brand-line">SOPs Nobody Reads</div>
+  </footer>
+</div>
+
+</body>
+</html>


### PR DESCRIPTION
Closes #1

Adds `courses/ai-onboarding/builds/index.html` — the course table of contents / landing page.

- Same design system as module players (Playfair Display, Source Serif 4, DM Sans, dark/cream/gold palette)
- 6 module cards with titles, part labels, and status badges
- Modules 1-2 linked and clickable, 3-6 shown as "Coming Soon"
- Film grain, vignette, scanline overlays matching module aesthetic
- Responsive grid layout
- No images, pure typography

Built by Claude Code on Issue #1.