### PR TITLE
Add home button to module player bottom bar

### DIFF
--- a/courses/ai-onboarding/builds/module-02/index.html
+++ b/courses/ai-onboarding/builds/module-02/index.html
@@ -753,6 +753,7 @@ html, body {
   <div class="slide-container" id="slideContainer"></div>
 
   <div class="bottom-bar">
+    <a href="../index.html" class="nav-btn" style="margin-right: 2vw;">MENU</a>
     <div class="progress-section">
       <div class="progress-track">
         <div class="progress-fill" id="progressFill"></div>


### PR DESCRIPTION
Closes #2

Adds MENU button to module player bottom bar:
- Home/menu button on left side of bottom bar, before progress track
- Links to `../index.html` (course landing page)
- Uses existing `nav-btn` styling for consistency
- Added `margin-right: 2vw` for proper spacing

Built by Claude Code on Issue #2.