### PR TITLE
Landing page CTA refresh + grey out Modules 3-6 + title fix

### DIFF
--- a/courses/ai-onboarding/builds/index.html
+++ b/courses/ai-onboarding/builds/index.html
@@ -149,6 +149,34 @@ html, body {
   box-shadow: 0 8px 32px rgba(201,168,76,0.15);
 }
 
+.module-card.coming-soon {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.module-card.coming-soon:hover {
+  transform: none;
+  border-color: rgba(240,232,216,0.08);
+  background: rgba(42,38,32,0.7);
+  box-shadow: none;
+}
+
+.coming-soon-badge {
+  position: absolute;
+  top: 1vh;
+  right: 1.5vw;
+  background: var(--rust);
+  color: var(--cream);
+  font-family: var(--font-ui);
+  font-size: 0.65rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  padding: 0.5vh 1vw;
+  border-radius: 3px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.3);
+}
+
 
 .module-number {
   font-family: var(--font-display);
@@ -326,7 +354,8 @@ html, body {
 <div class="container">
   <header class="header">
     <div class="course-label">Professional Development</div>
-    <h1 class="course-title">AI Onboarding: <span style="font-weight: 400; font-style: italic;">A Course for Humans</span></h1>
+    <h1 class="course-title">AI Onboarding:<br>
+<span style="white-space: nowrap;"><em>A Course for Humans</em></span></h1>
     <p class="course-description">
       A 6-module course teaching employees how to work effectively with AI tools. 
       Learn what AI actually is, why the usual approaches fail, and how to build productive workflows that leverage these powerful but alien systems.
@@ -348,25 +377,29 @@ html, body {
       <div class="module-part">Part One — Know Thy Machine</div>
     </article>
 
-    <article class="module-card available" onclick="window.location.href='module-03/index.html'">
+    <article class="module-card coming-soon">
+      <div class="coming-soon-badge">Coming Soon</div>
       <div class="module-number">Module 3</div>
       <h2 class="module-title">How It Actually Works (The 2-Minute Version)</h2>
       <div class="module-part">Part Two — The Prerequisites Nobody Mentions</div>
     </article>
 
-    <article class="module-card available" onclick="window.location.href='module-04/index.html'">
+    <article class="module-card coming-soon">
+      <div class="coming-soon-badge">Coming Soon</div>
       <div class="module-number">Module 4</div>
       <h2 class="module-title">The Real Problem Is You (And That's Good News)</h2>
       <div class="module-part">Part Two — The Prerequisites Nobody Mentions</div>
     </article>
 
-    <article class="module-card available" onclick="window.location.href='module-05/index.html'">
+    <article class="module-card coming-soon">
+      <div class="coming-soon-badge">Coming Soon</div>
       <div class="module-number">Module 5</div>
       <h2 class="module-title">The Prompt Is the Product</h2>
       <div class="module-part">Part Three — The Technical Layer</div>
     </article>
 
-    <article class="module-card available" onclick="window.location.href='module-06/index.html'">
+    <article class="module-card coming-soon">
+      <div class="coming-soon-badge">Coming Soon</div>
       <div class="module-number">Module 6</div>
       <h2 class="module-title">The Rules of the Road</h2>
       <div class="module-part">Part Three — The Technical Layer</div>
@@ -374,9 +407,9 @@ html, body {
   </main>
 
   <section class="contact-section">
-    <h2 class="contact-heading">Bring This Course to Your Team</h2>
+    <h2 class="contact-heading">Want This For Your Team?</h2>
     <p class="contact-subtext">
-      Interested in rolling out AI training across your organization? Get in touch to discuss custom implementations, bulk licensing, and enterprise features.
+      This is a sample of what we build. Your version would use your SOPs, your procedures, your compliance requirements — same format, customized to your operation. If you want to see what that looks like, let's talk.
     </p>
     <form class="contact-form" action="https://formspree.io/f/PLACEHOLDER" method="POST">
       <div class="form-row">
@@ -384,8 +417,7 @@ html, body {
         <input type="email" name="email" placeholder="Email" required>
       </div>
       <input type="text" name="company" placeholder="Company">
-      <textarea name="message" placeholder="Tell us about your training needs (optional)"></textarea>
-      <button type="submit">Request Information</button>
+      <button type="submit">Let's Talk</button>
     </form>
   </section>
 


### PR DESCRIPTION
Closes #10

## Summary
Updated the course landing page with three key changes:

1. **New CTA section**: Replaced "Bring This Course to Your Team" with "Want This For Your Team?" and updated copy to emphasize customization
2. **Greyed out modules 3-6**: Added "Coming Soon" badges, reduced opacity, and made them non-clickable
3. **Fixed title line break**: Added white-space: nowrap to prevent subtitle from breaking mid-phrase

All changes maintain the existing design system and visual consistency.

Generated with [Claude Code](https://claude.ai/code)