### PR TITLE
Fix Module 1 black screen - remove orphaned waitlist code

### DIFF
--- a/courses/ai-onboarding/builds/module-01/index.html
+++ b/courses/ai-onboarding/builds/module-01/index.html
@@ -1141,10 +1141,6 @@ const MODULE = {
     scormCommit();
   }
 
-    document.getElementById('waitlistForm').style.display = 'none';
-    document.getElementById('waitlistSuccess').style.display = 'block';
-  };
-
   // SCORM API — safe for cross-origin iframes
   let SCORM_API = null;
 


### PR DESCRIPTION
Fixes #16

Removed orphaned JavaScript code that was trying to access non-existent DOM elements (waitlistForm and waitlistSuccess). This code was causing immediate JavaScript errors that prevented the slide rendering system from working.

Module 1 should now render all slides and show proper progress (e.g. "1 / 31" instead of "1 / 1").

Generated with [Claude Code](https://claude.ai/code)