### PR TITLE
Un-grey Module 3 on landing page — images complete

### DIFF
--- a/courses/ai-onboarding/builds/index.html
+++ b/courses/ai-onboarding/builds/index.html
@@ -377,8 +377,7 @@ html, body {
       <div class="module-part">Part One — Know Thy Machine</div>
     </article>
 
-    <article class="module-card coming-soon">
-      <div class="coming-soon-badge">Coming Soon</div>
+    <article class="module-card available" onclick="window.location.href='module-03/index.html'">
       <div class="module-number">Module 3</div>
       <h2 class="module-title">How It Actually Works (The 2-Minute Version)</h2>
       <div class="module-part">Part Two — The Prerequisites Nobody Mentions</div>


### PR DESCRIPTION
Closes #22

Updated Module 3 card on the landing page to make it clickable and remove the "Coming Soon" status, since the images are now complete.

## Changes
- Removed "Coming Soon" badge from Module 3 card
- Changed CSS class from `coming-soon` to `available`
- Added onclick handler for navigation to module-03/index.html
- Modules 4-6 remain greyed out with Coming Soon badges as requested

Generated with [Claude Code](https://claude.ai/code)