### PR TITLE
Fix part labels on landing page — Modules 3-6 show wrong part names

### DIFF
--- a/courses/ai-onboarding/builds/index.html
+++ b/courses/ai-onboarding/builds/index.html
@@ -380,28 +380,28 @@ html, body {
     <article class="module-card available" onclick="window.location.href='module-03/index.html'">
       <div class="module-number">Module 3</div>
       <h2 class="module-title">How It Actually Works (The 2-Minute Version)</h2>
-      <div class="module-part">Part Two — The Prerequisites Nobody Mentions</div>
+      <div class="module-part">Part One — Know Thy Machine</div>
     </article>
 
     <article class="module-card coming-soon">
       <div class="coming-soon-badge">Coming Soon</div>
       <div class="module-number">Module 4</div>
       <h2 class="module-title">The Real Problem Is You (And That's Good News)</h2>
-      <div class="module-part">Part Two — The Prerequisites Nobody Mentions</div>
+      <div class="module-part">Part Two — Work With the Machine</div>
     </article>
 
     <article class="module-card coming-soon">
       <div class="coming-soon-badge">Coming Soon</div>
       <div class="module-number">Module 5</div>
       <h2 class="module-title">The Prompt Is the Product</h2>
-      <div class="module-part">Part Three — The Technical Layer</div>
+      <div class="module-part">Part Two — Work With the Machine</div>
     </article>
 
     <article class="module-card coming-soon">
       <div class="coming-soon-badge">Coming Soon</div>
       <div class="module-number">Module 6</div>
       <h2 class="module-title">The Rules of the Road</h2>
-      <div class="module-part">Part Three — The Technical Layer</div>
+      <div class="module-part">Part Two — Work With the Machine</div>
     </article>
   </main>
 


### PR DESCRIPTION
Closes #29

Fixed the incorrect part labels on the course landing page. Modules 3-6 were showing wrong part names, creating a three-part course structure instead of the correct two-part structure.

## Changes
- Module 3: Part One — Know Thy Machine (was Part Two)
- Module 4: Part Two — Work With the Machine (was Part Two — The Prerequisites)
- Module 5: Part Two — Work With the Machine (was Part Three)
- Module 6: Part Two — Work With the Machine (was Part Three)

Course now correctly shows two parts:
- Part One — Know Thy Machine (Modules 1-3)
- Part Two — Work With the Machine (Modules 4-6)

Generated with [Claude Code](https://claude.ai/code)