### PR TITLE
Un-grey Module 4 on landing page — images and script complete

### DIFF
--- a/courses/ai-onboarding/builds/index.html
+++ b/courses/ai-onboarding/builds/index.html
@@ -383,8 +383,7 @@ html, body {
       <div class="module-part">Part One — Know Thy Machine</div>
     </article>
 
-    <article class="module-card coming-soon">
-      <div class="coming-soon-badge">Coming Soon</div>
+    <article class="module-card available" onclick="window.location.href='module-04/index.html'">
       <div class="module-number">Module 4</div>
       <h2 class="module-title">The Real Problem Is You (And That's Good News)</h2>
       <div class="module-part">Part Two — Work With the Machine</div>


### PR DESCRIPTION
Closes #32

Updated the landing page to make Module 4 clickable now that images and script are complete.

## Changes
- Removed "Coming Soon" badge from Module 4 card
- Changed class from `coming-soon` to `available`
- Added onclick handler linking to module-04/index.html
- Module 4 now matches the pattern of Modules 1-3
- Modules 5-6 remain greyed out with "Coming Soon" badges

Generated with [Claude Code](https://claude.ai/code)