### PR TITLE
Un-grey Module 5 on landing page

### DIFF
--- a/courses/ai-onboarding/builds/index.html
+++ b/courses/ai-onboarding/builds/index.html
@@ -389,8 +389,7 @@ html, body {
       <div class="module-part">Part Two — Work With the Machine</div>
     </article>
 
-    <article class="module-card coming-soon">
-      <div class="coming-soon-badge">Coming Soon</div>
+    <article class="module-card available" onclick="window.location.href='module-05/index.html'">
       <div class="module-number">Module 5</div>
       <h2 class="module-title">The Prompt Is the Product</h2>
       <div class="module-part">Part Two — Work With the Machine</div>


### PR DESCRIPTION
Closes #38

Un-greyed Module 5 on the course landing page by removing its disabled state.

## Changes
- Remove `coming-soon` class and badge from Module 5
- Add `available` class and onclick handler
- Module 5 now clickable like Modules 1-4
- Module 6 remains greyed as requested

Generated with [Claude Code](https://claude.ai/code)