### PR TITLE
Un-grey Module 6 on landing page — all modules now live

### DIFF
--- a/courses/ai-onboarding/builds/index.html
+++ b/courses/ai-onboarding/builds/index.html
@@ -395,8 +395,7 @@ html, body {
       <div class="module-part">Part Two — Work With the Machine</div>
     </article>
 
-    <article class="module-card coming-soon">
-      <div class="coming-soon-badge">Coming Soon</div>
+    <article class="module-card available" onclick="window.location.href='module-06/index.html'">
       <div class="module-number">Module 6</div>
       <h2 class="module-title">The Rules of the Road</h2>
       <div class="module-part">Part Two — Work With the Machine</div>


### PR DESCRIPTION
Closes #40

Un-greyed Module 6 on the course landing page, making it clickable like the other modules.

## Changes
- Changed class from `coming-soon` to `available`
- Added onclick handler to link to module-06/index.html
- Removed "Coming Soon" badge
- Module 6 now matches pattern of other active modules

All 6 modules are now active on the landing page.

Generated with [Claude Code](https://claude.ai/code)