### PR TITLE
feat(loto): Build Module 2 & 3 players with Industrial theme

### DIFF
--- a/courses/loto/builds/.gitkeep
+++ b/courses/loto/builds/.gitkeep
@@ -1,0 +1,1 @@
+# LOTO course builds directory

--- a/courses/loto/builds/module-01.json
+++ b/courses/loto/builds/module-01.json
@@ -1,0 +1,100 @@
+{
+  "title": "The Energy You Don't See",
+  "moduleNumber": 1,
+  "partLabel": "Part One — Respect the Simple Thing",
+  "passingScore": 75,
+
+  "slides": [
+    { "type": "title", "moduleLabel": "Module 1", "heading": "The Energy\nYou Don't See", "subtitle": "Part One — Respect the Simple Thing", "brand": "SOPs Nobody Reads" },
+    
+    { "type": "scene", "label": "Cold Open", "text": "This is a Tuesday morning. Nothing about it is unusual. A worker picks up a work order — bearing replacement. Twenty-minute job. He's done it a hundred times.", "image": "img/s01-tuesday-morning.jpg" },
+    
+    { "type": "scene", "label": "Scene", "text": "He presses the stop button on the conveyor. The belt slows. Stops. He opens the access panel, pulls out a wrench, and starts loosening a bolt on the roller bearing.", "image": "img/s02-working-inside.jpg" },
+    
+    { "type": "concept", "label": "The Problem", "boxText": "He pressed the stop button. The belt isn't moving. So he's working.", "body": "But the electrical disconnect ten feet away has no lock. No tag. Just an unprotected switch that anyone could flip.", "image": "img/s03-unlocked-disconnect.jpg" },
+    
+    { "type": "keypoint", "kicker": "The Difference", "heading": "He stopped the machine.\nHe didn't secure it.", "body": "There's a difference. And the difference is everything.", "image": "img/s04-the-difference.jpg" },
+    
+    { "type": "keypoint", "kicker": "What Most People Think", "heading": "LOTO is just putting\na padlock on a breaker", "body": "And that's not wrong, exactly. But it's so incomplete that it might as well be. Lockout/tagout isn't a procedure. It's a barrier. The only barrier between you and the energy stored in the machine.", "image": "img/s05-simple-padlock.jpg" },
+    
+    { "type": "keypoint", "kicker": "Five Types of Energy", "heading": "Most people think\nelectricity.", "body": "But OSHA's Control of Hazardous Energy standard recognizes five types. And if you only think about one of them, the other four can kill you while you're busy being careful about electricity.", "image": "img/s06-electrical-symbol.jpg" },
+    
+    { "type": "concept", "label": "Electrical Energy", "boxText": "Current flowing through conductors. Touch the wrong thing and current flows through you instead of the wire.", "body": "But even after you cut the power, capacitors in motors and control boards can store charge and discharge it through you in a fraction of a second.", "image": "img/s07-electrical-panel.jpg" },
+    
+    { "type": "concept", "label": "Mechanical Energy", "boxText": "Moving parts under load. Springs, counterweights, rotating equipment.", "body": "A spring compressed to 100 pounds of force stays compressed until something releases it. If that something is your hand in the wrong place, the spring doesn't care.", "image": "img/s08-mechanical-parts.jpg" },
+    
+    { "type": "concept", "label": "Pneumatic Energy", "boxText": "Compressed air systems. Air tools, cylinders, automated equipment.", "body": "Compressed air at 90 PSI has enough force to drive a nail through your hand. A cylinder retracting can crush bone. Air doesn't make noise until it moves.", "image": "img/s09-pneumatic-system.jpg" },
+    
+    { "type": "concept", "label": "Hydraulic Energy", "boxText": "Fluid under pressure. Lifts, presses, heavy machinery controls.", "body": "Hydraulic fluid under 3000 PSI can inject through your skin and into your bloodstream. The wound looks minor. The internal damage can be fatal.", "image": "img/s10-hydraulic-system.jpg" },
+    
+    { "type": "concept", "label": "Stored Energy", "boxText": "Gravity, elevated components, pressurized systems, chemical reactions.", "body": "A suspended load doesn't announce itself. A pressurized vessel looks the same full or empty. Stored energy is patient. It waits.", "image": "img/s11-stored-energy.jpg" },
+    
+    { "type": "keypoint", "kicker": "The Real Danger", "heading": "Energy doesn't care\nabout your assumptions", "body": "You can't see most of these energies. You can't hear them. You can't feel them until it's too late. The machine looks safe, sounds safe, seems safe. Right up until it isn't.", "image": "img/s12-invisible-danger.jpg" },
+    
+    { "type": "reveal", "kicker": "The Point", "heading": "Two minutes\nand a padlock", "body": "That's all that stands between you and forces that can kill you instantly. Two minutes to identify the energy sources. Two minutes to isolate them. Two minutes to verify they're controlled.", "image": "img/s13-two-minutes-padlock.jpg" },
+    
+    { "type": "scene", "label": "Back to the Worker", "text": "The worker from our cold open finishes the bearing replacement. He closes the access panel, collects his tools, and walks away. <em>The disconnect is still unlocked.</em>", "image": "img/s14-worker-leaves.jpg" },
+    
+    { "type": "keypoint", "kicker": "The Next Day", "heading": "Someone else\nflips the switch", "body": "Maybe they don't see the worker inside. Maybe they assume someone else checked. Maybe they think it's fine because the machine is stopped. It doesn't matter why. What matters is what happens next.", "image": "img/s15-someone-flips-switch.jpg" },
+    
+    { "type": "list", "label": "What You Just Learned", "heading": "Module 1 — Key Points", "items": [
+      { "num": "1.", "text": "<strong>Five types of hazardous energy:</strong> electrical, mechanical, pneumatic, hydraulic, and stored energy" },
+      { "num": "2.", "text": "<strong>Energy is invisible:</strong> you can't see, hear, or feel most energy sources until they hurt you" },
+      { "num": "3.", "text": "<strong>Stopping ≠ securing:</strong> hitting the stop button doesn't control the energy in the system" },
+      { "num": "4.", "text": "<strong>Two minutes and a padlock:</strong> that's all that stands between you and potentially fatal energy" },
+      { "num": "5.", "text": "<strong>Energy doesn't care:</strong> about your experience, your assumptions, or your good intentions" }
+    ], "image": "img/s16-key-points.jpg" },
+    
+    { "type": "summary", "heading": "Module 1 — Key Concepts", "items": [
+      "LOTO is a barrier, not just a procedure",
+      "Five types of hazardous energy exist in most workplaces",
+      "Energy sources are often invisible and silent",
+      "Stopping equipment doesn't secure it",
+      "Two minutes of proper procedure can save your life",
+      "Everyone goes home safe"
+    ] }
+  ],
+
+  "quiz": [
+    {
+      "question": "How many types of hazardous energy does OSHA recognize in the Control of Hazardous Energy standard?",
+      "options": [
+        "Three: electrical, mechanical, and chemical",
+        "Four: electrical, mechanical, hydraulic, and pneumatic", 
+        "Five: electrical, mechanical, pneumatic, hydraulic, and stored energy",
+        "Six: electrical, mechanical, pneumatic, hydraulic, stored, and thermal"
+      ],
+      "correct": 2
+    },
+    {
+      "question": "Why is stored energy particularly dangerous?",
+      "options": [
+        "It makes loud noises that can damage hearing",
+        "It's patient — energy waits until released, often unexpectedly",
+        "It only affects electrical systems",
+        "It dissipates quickly and becomes harmless"
+      ],
+      "correct": 1
+    },
+    {
+      "question": "What's the difference between stopping a machine and securing it?",
+      "options": [
+        "There is no difference — they mean the same thing",
+        "Stopping turns off power; securing involves maintenance",
+        "Stopping halts operation; securing controls all energy sources with locks/tags", 
+        "Stopping is temporary; securing is permanent"
+      ],
+      "correct": 2
+    },
+    {
+      "question": "According to the module, what stands between you and potentially fatal energy?",
+      "options": [
+        "Your experience and training",
+        "Safety equipment and protective gear",
+        "Two minutes and a padlock",
+        "Company policies and procedures"
+      ],
+      "correct": 2
+    }
+  ]
+}

--- a/courses/loto/builds/module-01/img/.gitkeep
+++ b/courses/loto/builds/module-01/img/.gitkeep
@@ -1,0 +1,1 @@
+# Images for LOTO Module 1

--- a/courses/loto/builds/module-01/index.html
+++ b/courses/loto/builds/module-01/index.html
@@ -1,0 +1,1158 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Module 1: The Energy You Don't See | SOPs Nobody Reads</title>
+<style>
+/* ============================================
+   SOPs Nobody Reads — Module Player
+   Aesthetic: Industrial Safety / OSHA Training
+   Industrial theme: Steel, safety yellow, warning red
+   ============================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@300;400;600;700&family=Source+Sans+Pro:ital,wght@0,400;0,600;0,700;1,400&family=Inter:wght@400;500;600&display=swap');
+
+:root {
+  --bg-dark: #1a1a1a;
+  --bg-card: #2a2a2a;
+  --bg-warm: #333333;
+  --steel: #e5e7eb;
+  --steel-dim: #9ca3af;
+  --safety-yellow: #fbbf24;
+  --warning-red: #ef4444;
+  --caution-orange: #f59e0b;
+  --steel-blue: #64748b;
+  --steel-blue-light: #94a3b8;
+  --success-green: #10b981;
+  --dark-red: #7f1d1d;
+  --dark-green: #14532d;
+  --charcoal: #374151;
+  --font-display: 'Roboto Slab', Georgia, serif;
+  --font-body: 'Source Sans Pro', 'Segoe UI', sans-serif;
+  --font-ui: 'Inter', 'Segoe UI', sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg-dark);
+  color: var(--steel);
+}
+
+.grain {
+  position: fixed;
+  top: -50%; left: -50%;
+  width: 200%; height: 200%;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: 0.04;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.95' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  animation: grainShift 0.8s steps(4) infinite;
+}
+@keyframes grainShift {
+  0% { transform: translate(0, 0); }
+  25% { transform: translate(-2%, -1%); }
+  50% { transform: translate(1%, 2%); }
+  75% { transform: translate(-1%, -2%); }
+  100% { transform: translate(2%, 1%); }
+}
+
+.vignette {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9998;
+  background: radial-gradient(ellipse at center, transparent 50%, rgba(0,0,0,0.4) 100%);
+}
+
+.player {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-body);
+}
+
+.slide-container {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
+
+.slide {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 4vh 8vw;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+  pointer-events: none;
+  background-color: var(--bg-dark);
+}
+.slide.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* --- Background image support --- */
+.slide.has-image {
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.slide.has-image::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: radial-gradient(ellipse at center,
+    rgba(26,26,26,0.6) 0%,
+    rgba(26,26,26,0.82) 100%);
+}
+
+.slide-scene.has-image::before {
+  background: radial-gradient(ellipse at center,
+    rgba(26,26,26,0.68) 0%,
+    rgba(26,26,26,0.88) 100%);
+}
+
+.slide-concept.has-image::before {
+  background: radial-gradient(ellipse at center,
+    rgba(26,26,26,0.65) 0%,
+    rgba(26,26,26,0.85) 100%);
+}
+
+.slide-options.has-image::before {
+  background: radial-gradient(ellipse at center,
+    rgba(26,26,26,0.58) 0%,
+    rgba(26,26,26,0.82) 100%);
+}
+
+.slide-list.has-image::before {
+  background: radial-gradient(ellipse at center,
+    rgba(26,26,26,0.65) 0%,
+    rgba(26,26,26,0.85) 100%);
+}
+
+.slide.has-image > * {
+  position: relative;
+  z-index: 2;
+}
+
+/* --- Slide type styles --- */
+
+.slide-title {
+  text-align: center;
+  background: linear-gradient(170deg, var(--bg-warm) 0%, var(--bg-dark) 100%);
+}
+.slide-title .module-label {
+  font-family: var(--font-ui);
+  font-size: clamp(0.7rem, 1.2vw, 0.9rem);
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: var(--safety-yellow);
+  margin-bottom: 2vh;
+  font-weight: 600;
+}
+.slide-title h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 5vw, 4.5rem);
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--steel);
+  margin-bottom: 2vh;
+}
+.slide-title .subtitle {
+  font-family: var(--font-body);
+  font-size: clamp(0.9rem, 1.8vw, 1.3rem);
+  color: var(--steel-dim);
+  font-style: italic;
+  font-weight: 400;
+}
+.slide-title .brand {
+  position: absolute;
+  bottom: 4vh;
+  font-family: var(--font-ui);
+  font-size: 0.7rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--steel-blue);
+}
+
+.slide-scene {
+  text-align: center;
+  background: linear-gradient(170deg, #2a2a2a 0%, var(--bg-dark) 100%);
+}
+.slide-scene .scene-label {
+  font-family: var(--font-ui);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--caution-orange);
+  margin-bottom: 1vh;
+}
+.slide-scene p {
+  font-size: clamp(1.1rem, 2.2vw, 1.8rem);
+  line-height: 1.4;
+  color: var(--steel);
+  max-width: 65vw;
+  font-style: italic;
+}
+.slide-scene em {
+  color: var(--warning-red);
+  font-weight: 600;
+  font-style: normal;
+}
+
+.slide-keypoint {
+  text-align: center;
+  background: linear-gradient(170deg, #222 0%, var(--bg-dark) 100%);
+}
+.slide-keypoint .kicker {
+  font-family: var(--font-ui);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--safety-yellow);
+  margin-bottom: 2vh;
+  font-weight: 600;
+}
+.slide-keypoint h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 4.5vw, 3.5rem);
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--steel);
+  margin-bottom: 3vh;
+  max-width: 80vw;
+}
+.slide-keypoint .body {
+  font-size: clamp(0.95rem, 1.8vw, 1.25rem);
+  line-height: 1.5;
+  color: var(--steel-dim);
+  max-width: 70vw;
+}
+
+.slide-reveal {
+  text-align: center;
+  background: linear-gradient(170deg, var(--bg-warm) 0%, var(--bg-dark) 100%);
+}
+.slide-reveal .kicker {
+  font-family: var(--font-ui);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--safety-yellow);
+  margin-bottom: 2vh;
+  font-weight: 600;
+}
+.slide-reveal h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 4.5vw, 3.5rem);
+  font-weight: 700;
+  line-height: 1.15;
+  color: var(--steel);
+  margin-bottom: 3vh;
+  max-width: 80vw;
+}
+.slide-reveal .body {
+  font-size: clamp(1rem, 2vw, 1.4rem);
+  line-height: 1.4;
+  color: var(--steel-blue);
+  max-width: 65vw;
+  font-style: italic;
+}
+
+.slide-concept {
+  text-align: center;
+  background: linear-gradient(170deg, #1e1e1e 0%, var(--bg-dark) 100%);
+}
+.slide-concept .concept-label {
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--safety-yellow);
+  margin-bottom: 3vh;
+  font-weight: 600;
+}
+.slide-concept .concept-box {
+  background: var(--charcoal);
+  border: 2px solid var(--safety-yellow);
+  border-radius: 8px;
+  padding: 2.5vh 3vw;
+  margin: 0 auto 3vh;
+  max-width: 75vw;
+}
+.slide-concept .box-text {
+  font-size: clamp(1.1rem, 2.2vw, 1.6rem);
+  line-height: 1.4;
+  color: var(--steel);
+  font-weight: 600;
+}
+.slide-concept .body {
+  font-size: clamp(0.9rem, 1.7vw, 1.2rem);
+  line-height: 1.5;
+  color: var(--steel-dim);
+  max-width: 70vw;
+}
+
+.slide-list {
+  padding-left: 10vw;
+  background: linear-gradient(170deg, #1e1e1e 0%, var(--bg-dark) 100%);
+}
+.slide-list .list-label {
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--safety-yellow);
+  margin-bottom: 2vh;
+  font-weight: 600;
+}
+.slide-list h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.6rem, 3.5vw, 2.8rem);
+  font-weight: 700;
+  color: var(--steel);
+  margin-bottom: 4vh;
+  line-height: 1.2;
+}
+.slide-list .list-items {
+  list-style: none;
+}
+.slide-list .list-item {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 2.5vh;
+  max-width: 70vw;
+}
+.slide-list .item-num {
+  font-family: var(--font-ui);
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--safety-yellow);
+  margin-right: 1.5vw;
+  min-width: 2rem;
+}
+.slide-list .item-text {
+  font-size: clamp(0.9rem, 1.7vw, 1.2rem);
+  line-height: 1.5;
+  color: var(--steel-dim);
+}
+.slide-list strong {
+  color: var(--steel);
+  font-weight: 600;
+}
+
+.slide-summary {
+  text-align: center;
+  background: linear-gradient(170deg, var(--bg-warm) 0%, var(--bg-dark) 100%);
+}
+.slide-summary h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.5rem, 3.2vw, 2.5rem);
+  font-weight: 700;
+  color: var(--steel);
+  margin-bottom: 4vh;
+  line-height: 1.2;
+}
+.slide-summary .summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5vh;
+  max-width: 80vw;
+}
+.slide-summary .summary-item {
+  font-size: clamp(0.85rem, 1.5vw, 1.1rem);
+  line-height: 1.4;
+  color: var(--steel-dim);
+  text-align: left;
+  padding: 0.5vh 0;
+}
+.slide-summary .summary-item::before {
+  content: "—";
+  color: var(--safety-yellow);
+  margin-right: 0.5em;
+  font-weight: 600;
+}
+
+.slide-options {
+  text-align: center;
+  background: linear-gradient(170deg, #222 0%, var(--bg-dark) 100%);
+}
+.slide-options h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.4rem, 3vw, 2.3rem);
+  font-weight: 700;
+  color: var(--steel);
+  margin-bottom: 4vh;
+  line-height: 1.3;
+  max-width: 80vw;
+}
+.slide-options .options-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2vh;
+  max-width: 75vw;
+}
+.slide-options .option {
+  display: flex;
+  align-items: center;
+  background: var(--bg-card);
+  border: 2px solid transparent;
+  border-radius: 8px;
+  padding: 2vh 2.5vw;
+  text-align: left;
+  transition: all 0.3s ease;
+}
+.slide-options .option.highlighted {
+  border-color: var(--safety-yellow);
+  background: rgba(251, 191, 36, 0.1);
+}
+.slide-options .option-letter {
+  font-family: var(--font-ui);
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--safety-yellow);
+  background: var(--charcoal);
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 2vw;
+  flex-shrink: 0;
+}
+.slide-options .option-content h3 {
+  font-size: clamp(0.95rem, 1.8vw, 1.3rem);
+  font-weight: 600;
+  color: var(--steel);
+  margin-bottom: 0.5vh;
+}
+.slide-options .option-content p {
+  font-size: clamp(0.8rem, 1.5vw, 1.1rem);
+  line-height: 1.4;
+  color: var(--steel-dim);
+}
+
+/* --- Bottom Bar --- */
+
+.bottom-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5vh 3vw;
+  background: var(--charcoal);
+  border-top: 1px solid var(--steel-blue);
+  font-family: var(--font-ui);
+}
+
+.nav-btn {
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--steel);
+  background: transparent;
+  border: 1px solid var(--steel-blue);
+  border-radius: 4px;
+  padding: 0.8rem 1.2rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-decoration: none;
+  display: inline-block;
+}
+.nav-btn:hover:not(:disabled) {
+  background: var(--safety-yellow);
+  color: var(--bg-dark);
+  border-color: var(--safety-yellow);
+}
+.nav-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.progress-section {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.progress-track {
+  width: 200px;
+  height: 6px;
+  background: var(--bg-dark);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.progress-fill {
+  height: 100%;
+  background: var(--safety-yellow);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+  width: 0%;
+}
+.progress-text {
+  font-size: 0.8rem;
+  color: var(--steel-dim);
+  min-width: 4rem;
+  text-align: center;
+}
+
+.nav-buttons {
+  display: flex;
+  gap: 1rem;
+}
+
+/* --- Quiz Styles --- */
+
+.quiz-container {
+  text-align: center;
+  max-width: 80vw;
+}
+.quiz-container h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.4rem, 3vw, 2.3rem);
+  font-weight: 700;
+  color: var(--steel);
+  margin-bottom: 4vh;
+  line-height: 1.3;
+}
+.quiz-options {
+  display: flex;
+  flex-direction: column;
+  gap: 2vh;
+  margin-bottom: 3vh;
+}
+.quiz-option {
+  display: flex;
+  align-items: center;
+  background: var(--bg-card);
+  border: 2px solid transparent;
+  border-radius: 8px;
+  padding: 2vh 2.5vw;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+.quiz-option:hover {
+  border-color: var(--steel-blue);
+}
+.quiz-option.selected {
+  border-color: var(--safety-yellow);
+  background: rgba(251, 191, 36, 0.1);
+}
+.quiz-option.correct {
+  border-color: var(--success-green);
+  background: rgba(16, 185, 129, 0.1);
+}
+.quiz-option.incorrect {
+  border-color: var(--warning-red);
+  background: rgba(239, 68, 68, 0.1);
+  opacity: 0.6;
+}
+.quiz-option .option-letter {
+  font-family: var(--font-ui);
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--safety-yellow);
+  background: var(--charcoal);
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 2vw;
+  flex-shrink: 0;
+}
+.quiz-option.correct .option-letter {
+  background: var(--success-green);
+  color: white;
+}
+.quiz-option.incorrect .option-letter {
+  background: var(--warning-red);
+  color: white;
+}
+.quiz-option .option-text {
+  font-size: clamp(0.9rem, 1.7vw, 1.2rem);
+  line-height: 1.4;
+  color: var(--steel);
+}
+
+.quiz-feedback {
+  font-size: clamp(0.85rem, 1.5vw, 1.1rem);
+  line-height: 1.4;
+  color: var(--steel-dim);
+  margin-top: 2vh;
+  padding: 2vh;
+  background: var(--bg-card);
+  border-radius: 6px;
+  border-left: 4px solid var(--safety-yellow);
+}
+
+/* Results slide */
+.results-container {
+  text-align: center;
+  max-width: 70vw;
+}
+.results-container h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 4vw, 3rem);
+  font-weight: 700;
+  color: var(--steel);
+  margin-bottom: 3vh;
+}
+.score-display {
+  font-size: clamp(2rem, 5vw, 4rem);
+  font-weight: 700;
+  margin: 3vh 0;
+}
+.score-display.pass {
+  color: var(--success-green);
+}
+.score-display.fail {
+  color: var(--warning-red);
+}
+.results-message {
+  font-size: clamp(1rem, 2vw, 1.4rem);
+  line-height: 1.4;
+  color: var(--steel-dim);
+  margin-bottom: 4vh;
+}
+.results-actions {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+.results-actions .nav-btn {
+  min-width: 8rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .slide {
+    padding: 3vh 5vw;
+  }
+  .progress-track {
+    width: 120px;
+  }
+  .nav-buttons {
+    gap: 0.5rem;
+  }
+  .nav-btn {
+    font-size: 0.75rem;
+    padding: 0.6rem 0.8rem;
+  }
+  .slide-options .options-container,
+  .quiz-options {
+    max-width: 90vw;
+  }
+}
+
+@media (max-width: 480px) {
+  .slide {
+    padding: 2vh 4vw;
+  }
+  .bottom-bar {
+    padding: 1vh 2vw;
+  }
+  .progress-section {
+    gap: 0.5rem;
+  }
+  .progress-track {
+    width: 80px;
+  }
+}
+</style>
+</head>
+
+<body>
+<div class="grain"></div>
+<div class="vignette"></div>
+
+<div class="player" id="player">
+  <div class="slide-container" id="slideContainer"></div>
+
+  <div class="bottom-bar">
+    <a href="../index.html" class="nav-btn" style="margin-right: 2vw;">MENU</a>
+    <div class="progress-section">
+      <div class="progress-track">
+        <div class="progress-fill" id="progressFill"></div>
+      </div>
+      <span class="progress-text" id="progressText">1 / 1</span>
+    </div>
+    <div class="nav-buttons">
+      <button class="nav-btn" id="prevBtn" disabled>&#8592; Prev</button>
+      <button class="nav-btn" id="nextBtn">Next &#8594;</button>
+    </div>
+  </div>
+</div>
+
+<script>
+const MODULE = {
+  "title": "The Energy You Don't See",
+  "moduleNumber": 1,
+  "partLabel": "Part One — Respect the Simple Thing",
+  "passingScore": 75,
+  "slides": [
+    { "type": "title", "moduleLabel": "Module 1", "heading": "The Energy\nYou Don't See", "subtitle": "Part One — Respect the Simple Thing", "brand": "SOPs Nobody Reads" },
+    { "type": "scene", "label": "Cold Open", "text": "This is a Tuesday morning. Nothing about it is unusual. A worker picks up a work order — bearing replacement. Twenty-minute job. He's done it a hundred times.", "image": "img/s01-tuesday-morning.jpg" },
+    { "type": "scene", "label": "Scene", "text": "He presses the stop button on the conveyor. The belt slows. Stops. He opens the access panel, pulls out a wrench, and starts loosening a bolt on the roller bearing.", "image": "img/s02-working-inside.jpg" },
+    { "type": "concept", "label": "The Problem", "boxText": "He pressed the stop button. The belt isn't moving. So he's working.", "body": "But the electrical disconnect ten feet away has no lock. No tag. Just an unprotected switch that anyone could flip.", "image": "img/s03-unlocked-disconnect.jpg" },
+    { "type": "keypoint", "kicker": "The Difference", "heading": "He stopped the machine.\nHe didn't secure it.", "body": "There's a difference. And the difference is everything.", "image": "img/s04-the-difference.jpg" },
+    { "type": "keypoint", "kicker": "What Most People Think", "heading": "LOTO is just putting\na padlock on a breaker", "body": "And that's not wrong, exactly. But it's so incomplete that it might as well be. Lockout/tagout isn't a procedure. It's a barrier. The only barrier between you and the energy stored in the machine.", "image": "img/s05-simple-padlock.jpg" },
+    { "type": "keypoint", "kicker": "Five Types of Energy", "heading": "Most people think\nelectricity.", "body": "But OSHA's Control of Hazardous Energy standard recognizes five types. And if you only think about one of them, the other four can kill you while you're busy being careful about electricity.", "image": "img/s06-electrical-symbol.jpg" },
+    { "type": "concept", "label": "Electrical Energy", "boxText": "Current flowing through conductors. Touch the wrong thing and current flows through you instead of the wire.", "body": "But even after you cut the power, capacitors in motors and control boards can store charge and discharge it through you in a fraction of a second.", "image": "img/s07-electrical-panel.jpg" },
+    { "type": "concept", "label": "Mechanical Energy", "boxText": "Moving parts under load. Springs, counterweights, rotating equipment.", "body": "A spring compressed to 100 pounds of force stays compressed until something releases it. If that something is your hand in the wrong place, the spring doesn't care.", "image": "img/s08-mechanical-parts.jpg" },
+    { "type": "concept", "label": "Pneumatic Energy", "boxText": "Compressed air systems. Air tools, cylinders, automated equipment.", "body": "Compressed air at 90 PSI has enough force to drive a nail through your hand. A cylinder retracting can crush bone. Air doesn't make noise until it moves.", "image": "img/s09-pneumatic-system.jpg" },
+    { "type": "concept", "label": "Hydraulic Energy", "boxText": "Fluid under pressure. Lifts, presses, heavy machinery controls.", "body": "Hydraulic fluid under 3000 PSI can inject through your skin and into your bloodstream. The wound looks minor. The internal damage can be fatal.", "image": "img/s10-hydraulic-system.jpg" },
+    { "type": "concept", "label": "Stored Energy", "boxText": "Gravity, elevated components, pressurized systems, chemical reactions.", "body": "A suspended load doesn't announce itself. A pressurized vessel looks the same full or empty. Stored energy is patient. It waits.", "image": "img/s11-stored-energy.jpg" },
+    { "type": "keypoint", "kicker": "The Real Danger", "heading": "Energy doesn't care\nabout your assumptions", "body": "You can't see most of these energies. You can't hear them. You can't feel them until it's too late. The machine looks safe, sounds safe, seems safe. Right up until it isn't.", "image": "img/s12-invisible-danger.jpg" },
+    { "type": "reveal", "kicker": "The Point", "heading": "Two minutes\nand a padlock", "body": "That's all that stands between you and forces that can kill you instantly. Two minutes to identify the energy sources. Two minutes to isolate them. Two minutes to verify they're controlled.", "image": "img/s13-two-minutes-padlock.jpg" },
+    { "type": "scene", "label": "Back to the Worker", "text": "The worker from our cold open finishes the bearing replacement. He closes the access panel, collects his tools, and walks away. <em>The disconnect is still unlocked.</em>", "image": "img/s14-worker-leaves.jpg" },
+    { "type": "keypoint", "kicker": "The Next Day", "heading": "Someone else\nflips the switch", "body": "Maybe they don't see the worker inside. Maybe they assume someone else checked. Maybe they think it's fine because the machine is stopped. It doesn't matter why. What matters is what happens next.", "image": "img/s15-someone-flips-switch.jpg" },
+    { "type": "list", "label": "What You Just Learned", "heading": "Module 1 — Key Points", "items": [
+      { "num": "1.", "text": "<strong>Five types of hazardous energy:</strong> electrical, mechanical, pneumatic, hydraulic, and stored energy" },
+      { "num": "2.", "text": "<strong>Energy is invisible:</strong> you can't see, hear, or feel most energy sources until they hurt you" },
+      { "num": "3.", "text": "<strong>Stopping ≠ securing:</strong> hitting the stop button doesn't control the energy in the system" },
+      { "num": "4.", "text": "<strong>Two minutes and a padlock:</strong> that's all that stands between you and potentially fatal energy" },
+      { "num": "5.", "text": "<strong>Energy doesn't care:</strong> about your experience, your assumptions, or your good intentions" }
+    ], "image": "img/s16-key-points.jpg" },
+    { "type": "summary", "heading": "Module 1 — Key Concepts", "items": [
+      "LOTO is a barrier, not just a procedure",
+      "Five types of hazardous energy exist in most workplaces",
+      "Energy sources are often invisible and silent",
+      "Stopping equipment doesn't secure it",
+      "Two minutes of proper procedure can save your life",
+      "Everyone goes home safe"
+    ] }
+  ],
+  "quiz": [
+    {
+      "question": "How many types of hazardous energy does OSHA recognize in the Control of Hazardous Energy standard?",
+      "options": [
+        "Three: electrical, mechanical, and chemical",
+        "Four: electrical, mechanical, hydraulic, and pneumatic", 
+        "Five: electrical, mechanical, pneumatic, hydraulic, and stored energy",
+        "Six: electrical, mechanical, pneumatic, hydraulic, stored, and thermal"
+      ],
+      "correct": 2
+    },
+    {
+      "question": "Why is stored energy particularly dangerous?",
+      "options": [
+        "It makes loud noises that can damage hearing",
+        "It's patient — energy waits until released, often unexpectedly",
+        "It only affects electrical systems",
+        "It dissipates quickly and becomes harmless"
+      ],
+      "correct": 1
+    },
+    {
+      "question": "What's the difference between stopping a machine and securing it?",
+      "options": [
+        "There is no difference — they mean the same thing",
+        "Stopping turns off power; securing involves maintenance",
+        "Stopping halts operation; securing controls all energy sources with locks/tags", 
+        "Stopping is temporary; securing is permanent"
+      ],
+      "correct": 2
+    },
+    {
+      "question": "According to the module, what stands between you and potentially fatal energy?",
+      "options": [
+        "Your experience and training",
+        "Safety equipment and protective gear",
+        "Two minutes and a padlock",
+        "Company policies and procedures"
+      ],
+      "correct": 2
+    }
+  ]
+};
+
+// Player JavaScript (same as AI onboarding, no modifications needed)
+let currentSlide = 0;
+let quizAnswers = [];
+let quizMode = false;
+let currentQuizQuestion = 0;
+let isAnswered = false;
+
+function initPlayer() {
+  renderSlide();
+  updateProgress();
+  updateNavButtons();
+}
+
+function renderSlide() {
+  const container = document.getElementById('slideContainer');
+  
+  if (quizMode) {
+    renderQuiz();
+    return;
+  }
+  
+  const slide = MODULE.slides[currentSlide];
+  if (!slide) return;
+  
+  let html = '';
+  let slideClasses = `slide slide-${slide.type}`;
+  
+  if (slide.image) {
+    slideClasses += ' has-image';
+  }
+  
+  switch (slide.type) {
+    case 'title':
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <div class="module-label">${slide.moduleLabel}</div>
+          <h1>${slide.heading.replace(/\\n/g, '<br>')}</h1>
+          <div class="subtitle">${slide.subtitle}</div>
+          <div class="brand">${slide.brand}</div>
+        </div>
+      `;
+      break;
+      
+    case 'scene':
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <div class="scene-label">${slide.label}</div>
+          <p>${slide.text}</p>
+        </div>
+      `;
+      break;
+      
+    case 'keypoint':
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          ${slide.kicker ? `<div class="kicker">${slide.kicker}</div>` : ''}
+          <h2>${slide.heading.replace(/\\n/g, '<br>')}</h2>
+          <div class="body">${slide.body}</div>
+        </div>
+      `;
+      break;
+      
+    case 'reveal':
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <div class="kicker">${slide.kicker}</div>
+          <h2>${slide.heading.replace(/\\n/g, '<br>')}</h2>
+          <div class="body">${slide.body}</div>
+        </div>
+      `;
+      break;
+      
+    case 'concept':
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <div class="concept-label">${slide.label}</div>
+          <div class="concept-box">
+            <div class="box-text">${slide.boxText}</div>
+          </div>
+          <div class="body">${slide.body}</div>
+        </div>
+      `;
+      break;
+      
+    case 'list':
+      const listItems = slide.items.map(item => `
+        <div class="list-item">
+          <div class="item-num">${item.num}</div>
+          <div class="item-text">${item.text}</div>
+        </div>
+      `).join('');
+      
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <div class="list-label">${slide.label}</div>
+          <h2>${slide.heading}</h2>
+          <div class="list-items">
+            ${listItems}
+          </div>
+        </div>
+      `;
+      break;
+      
+    case 'summary':
+      const summaryItems = slide.items.map(item => `
+        <div class="summary-item">${item}</div>
+      `).join('');
+      
+      html = `
+        <div class="${slideClasses}">
+          <h2>${slide.heading}</h2>
+          <div class="summary-grid">
+            ${summaryItems}
+          </div>
+        </div>
+      `;
+      break;
+      
+    case 'options':
+      const options = slide.options.map(option => `
+        <div class="option ${slide.highlighted === option.letter ? 'highlighted' : ''}">
+          <div class="option-letter">${option.letter}</div>
+          <div class="option-content">
+            <h3>${option.title}</h3>
+            <p>${option.desc}</p>
+          </div>
+        </div>
+      `).join('');
+      
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <h2>${slide.heading}</h2>
+          <div class="options-container">
+            ${options}
+          </div>
+        </div>
+      `;
+      break;
+  }
+  
+  container.innerHTML = html;
+  
+  // Activate the slide
+  setTimeout(() => {
+    const slideEl = container.querySelector('.slide');
+    if (slideEl) slideEl.classList.add('active');
+  }, 50);
+}
+
+function renderQuiz() {
+  const container = document.getElementById('slideContainer');
+  
+  if (currentQuizQuestion >= MODULE.quiz.length) {
+    renderResults();
+    return;
+  }
+  
+  const question = MODULE.quiz[currentQuizQuestion];
+  const options = question.options.map((option, index) => {
+    const letter = String.fromCharCode(65 + index);
+    let classes = 'quiz-option';
+    
+    if (isAnswered) {
+      if (index === question.correct) {
+        classes += ' correct';
+      } else if (quizAnswers[currentQuizQuestion] === index) {
+        classes += ' incorrect';
+      }
+    } else if (quizAnswers[currentQuizQuestion] === index) {
+      classes += ' selected';
+    }
+    
+    return `
+      <div class="${classes}" onclick="${!isAnswered ? `selectAnswer(${index})` : ''}">
+        <div class="option-letter">${letter}</div>
+        <div class="option-text">${option}</div>
+      </div>
+    `;
+  }).join('');
+  
+  let feedback = '';
+  if (isAnswered) {
+    const isCorrect = quizAnswers[currentQuizQuestion] === question.correct;
+    feedback = `
+      <div class="quiz-feedback">
+        ${isCorrect ? 'Correct!' : 'Incorrect.'} ${getQuizFeedback(currentQuizQuestion)}
+      </div>
+    `;
+  }
+  
+  const html = `
+    <div class="slide slide-quiz active">
+      <div class="quiz-container">
+        <h2>Question ${currentQuizQuestion + 1}</h2>
+        <p style="margin-bottom: 3vh; color: var(--steel-dim); font-size: clamp(1rem, 2vw, 1.3rem);">
+          ${question.question}
+        </p>
+        <div class="quiz-options">
+          ${options}
+        </div>
+        ${feedback}
+      </div>
+    </div>
+  `;
+  
+  container.innerHTML = html;
+}
+
+function selectAnswer(answerIndex) {
+  if (isAnswered) return;
+  
+  quizAnswers[currentQuizQuestion] = answerIndex;
+  isAnswered = true;
+  renderQuiz();
+  updateNavButtons();
+}
+
+function getQuizFeedback(questionIndex) {
+  const feedbacks = [
+    "OSHA recognizes five types of hazardous energy in the Control of Hazardous Energy standard.",
+    "Stored energy is particularly dangerous because it's patient and waits to be released, often when least expected.",
+    "Stopping a machine halts its operation, but securing it means controlling all energy sources with proper lockout/tagout procedures.",
+    "The module emphasizes that just two minutes and a padlock are all that stand between you and potentially fatal energy."
+  ];
+  return feedbacks[questionIndex] || '';
+}
+
+function renderResults() {
+  const container = document.getElementById('slideContainer');
+  const correctAnswers = quizAnswers.filter((answer, index) => answer === MODULE.quiz[index].correct).length;
+  const totalQuestions = MODULE.quiz.length;
+  const percentage = Math.round((correctAnswers / totalQuestions) * 100);
+  const passed = percentage >= MODULE.passingScore;
+  
+  const html = `
+    <div class="slide slide-results active">
+      <div class="results-container">
+        <h2>Module ${MODULE.moduleNumber} Complete</h2>
+        <div class="score-display ${passed ? 'pass' : 'fail'}">
+          ${percentage}%
+        </div>
+        <div class="results-message">
+          ${correctAnswers} of ${totalQuestions} questions correct<br>
+          ${passed ? 'You passed! Well done.' : `You need ${MODULE.passingScore}% to pass. Please review the material and try again.`}
+        </div>
+        <div class="results-actions">
+          ${!passed ? `<button class="nav-btn" onclick="restartQuiz()">Try Again</button>` : ''}
+          <a href="../module-02/index.html" class="nav-btn">Next Module &#8594;</a>
+        </div>
+        <p style="margin-top: 3vh; font-size: 0.9rem; color: var(--steel-dim);">
+          Module 1 of 3 &mdash; Continue to learn the six-step LOTO procedure.
+        </p>
+      </div>
+    </div>
+  `;
+  
+  container.innerHTML = html;
+}
+
+function restartQuiz() {
+  quizAnswers = [];
+  currentQuizQuestion = 0;
+  isAnswered = false;
+  renderQuiz();
+  updateNavButtons();
+}
+
+function nextSlide() {
+  if (quizMode) {
+    if (isAnswered) {
+      if (currentQuizQuestion < MODULE.quiz.length - 1) {
+        currentQuizQuestion++;
+        isAnswered = false;
+        renderQuiz();
+      } else {
+        renderResults();
+      }
+    }
+  } else {
+    if (currentSlide < MODULE.slides.length - 1) {
+      currentSlide++;
+      renderSlide();
+    } else {
+      // Start quiz
+      quizMode = true;
+      currentQuizQuestion = 0;
+      isAnswered = false;
+      renderQuiz();
+    }
+  }
+  
+  updateProgress();
+  updateNavButtons();
+}
+
+function prevSlide() {
+  if (quizMode && currentQuizQuestion === 0) {
+    quizMode = false;
+    currentSlide = MODULE.slides.length - 1;
+    renderSlide();
+  } else if (quizMode) {
+    currentQuizQuestion--;
+    isAnswered = quizAnswers[currentQuizQuestion] !== undefined;
+    renderQuiz();
+  } else if (currentSlide > 0) {
+    currentSlide--;
+    renderSlide();
+  }
+  
+  updateProgress();
+  updateNavButtons();
+}
+
+function updateProgress() {
+  const totalSlides = MODULE.slides.length + MODULE.quiz.length;
+  const currentPos = quizMode ? MODULE.slides.length + currentQuizQuestion + 1 : currentSlide + 1;
+  const percentage = (currentPos / totalSlides) * 100;
+  
+  document.getElementById('progressFill').style.width = `${percentage}%`;
+  document.getElementById('progressText').textContent = `${currentPos} / ${totalSlides}`;
+}
+
+function updateNavButtons() {
+  const prevBtn = document.getElementById('prevBtn');
+  const nextBtn = document.getElementById('nextBtn');
+  
+  prevBtn.disabled = (!quizMode && currentSlide === 0) || (quizMode && currentQuizQuestion === 0 && currentSlide === 0);
+  
+  if (quizMode) {
+    nextBtn.disabled = !isAnswered;
+    if (currentQuizQuestion >= MODULE.quiz.length - 1 && isAnswered) {
+      nextBtn.textContent = 'Results ►';
+    } else {
+      nextBtn.textContent = 'Next ►';
+    }
+  } else {
+    nextBtn.disabled = false;
+    if (currentSlide === MODULE.slides.length - 1) {
+      nextBtn.textContent = 'Quiz ►';
+    } else {
+      nextBtn.textContent = 'Next ►';
+    }
+  }
+}
+
+// Event listeners
+document.getElementById('prevBtn').addEventListener('click', prevSlide);
+document.getElementById('nextBtn').addEventListener('click', nextSlide);
+
+// Keyboard navigation
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'ArrowRight' && !document.getElementById('nextBtn').disabled) {
+    nextSlide();
+  } else if (e.key === 'ArrowLeft' && !document.getElementById('prevBtn').disabled) {
+    prevSlide();
+  }
+});
+
+// Initialize player
+initPlayer();
+
+// SCORM API stubs (graceful degradation)
+window.API = window.API || {
+  LMSInitialize: () => 'true',
+  LMSCommit: () => 'true', 
+  LMSFinish: () => 'true',
+  LMSGetValue: () => '',
+  LMSSetValue: () => 'true',
+  LMSGetLastError: () => '0',
+  LMSGetErrorString: () => '',
+  LMSGetDiagnostic: () => ''
+};
+</script>
+</body>
+</html>

--- a/courses/loto/builds/module-02.json
+++ b/courses/loto/builds/module-02.json
@@ -1,0 +1,100 @@
+{
+  "title": "The Six Steps", 
+  "moduleNumber": 2,
+  "partLabel": "Part Two — The Procedure That Keeps You Alive",
+  "passingScore": 75,
+
+  "slides": [
+    { "type": "title", "moduleLabel": "Module 2", "heading": "The Six Steps", "subtitle": "Part Two — The Procedure That Keeps You Alive", "brand": "SOPs Nobody Reads" },
+    
+    { "type": "scene", "label": "Cold Open", "text": "A breaker panel in a hallway. Someone has taped a handwritten sign next to one of the breakers: <em>\"DO NOT TURN ON — Mike working on Line 3.\"</em> The tape is peeling at one corner.", "image": "img/s01-handwritten-sign.jpg" },
+    
+    { "type": "scene", "label": "Scene", "text": "A hand reaches past the sign and flips the breaker to ON. The sign flutters. The hand belongs to someone who didn't read it, or didn't think it applied to them.", "image": "img/s02-flips-breaker.jpg" },
+    
+    { "type": "reveal", "kicker": "The Difference", "heading": "A sign is not a lock.\nA sign is a request.\nA lock is a fact.", "body": "And the difference between a request and a fact is the distance between going home tonight and not.", "image": "img/s03-sign-vs-lock.jpg" },
+    
+    { "type": "keypoint", "kicker": "Why Order Matters", "heading": "Six steps.\nSix layers of protection.", "body": "Each step handles something the previous step couldn't. Skip a layer and there's a gap. A gap in this process is a gap in your protection.", "image": "img/s04-six-steps.jpg" },
+    
+    { "type": "keypoint", "kicker": "Step 1", "heading": "Prepare for Shutdown", "body": "Find the machine-specific lockout procedure. Know what you're dealing with. Notify affected employees. This isn't paperwork — it's your map. Without it, you're guessing.", "image": "img/s05-prepare.jpg" },
+    
+    { "type": "keypoint", "kicker": "Step 2", "heading": "Equipment Shutdown", "body": "Use normal stopping procedures. Verify all moving parts have actually stopped — not almost stopped, not slowing down. Stopped. Flywheels coast. Wait for zero.", "image": "img/s06-shutdown.jpg" },
+    
+    { "type": "keypoint", "kicker": "Step 3", "heading": "Energy Isolation", "body": "Disconnect from every energy source. Electric, pneumatic, hydraulic, mechanical. Turn breakers to OFF. Close valves. Disconnect supply lines. Isolation means no energy can reach the equipment.", "image": "img/s07-isolate.jpg" },
+    
+    { "type": "keypoint", "kicker": "Step 4", "heading": "Apply Lockout Devices", "body": "Lock every isolation point. One lock per person working on the equipment. Your lock, your key, your life. Remove only your own locks when your work is complete.", "image": "img/s08-lockout.jpg" },
+    
+    { "type": "keypoint", "kicker": "Step 5", "heading": "Stored Energy Control", "body": "Relieve, disconnect, or restrain stored energy. Bleed air pressure. Discharge capacitors. Support suspended components. Release spring tension safely. Stored energy is patient — it waits.", "image": "img/s09-stored-energy.jpg" },
+    
+    { "type": "keypoint", "kicker": "Step 6", "heading": "Verify Isolation", "body": "Test that the equipment cannot be operated. Try to start it using normal procedures. Check for movement, lights, sounds. Verify zero energy state before beginning work.", "image": "img/s10-verify.jpg" },
+    
+    { "type": "concept", "label": "One Person, One Lock", "boxText": "Each worker applies their own lock and removes only their own lock.", "body": "Your lock protects you. Someone else's lock protects them. You never remove another person's lock. They never remove yours. This isn't bureaucracy — it's survival.", "image": "img/s11-one-person-one-lock.jpg" },
+    
+    { "type": "concept", "label": "Tags vs. Locks", "boxText": "Tags inform. Locks prevent. Tags supplement locks — they never replace them.", "body": "A tag tells you who's working and why. But a tag won't stop someone from flipping a switch. Use both: lock to prevent, tag to inform.", "image": "img/s12-tags-vs-locks.jpg" },
+    
+    { "type": "keypoint", "kicker": "Why People Skip Steps", "heading": "\"I've done this job\na hundred times.\"", "body": "Experience creates shortcuts. Familiarity breeds assumption. The worker who skips LOTO is usually the experienced one — the one who knows the machine, knows the work, knows it'll only take five minutes.", "image": "img/s13-experienced-worker.jpg" },
+    
+    { "type": "reveal", "kicker": "The Psychology", "heading": "Every accident starts\nwith \"just this once.\"", "body": "Just this once I'll skip the lockout. Just this once I'll reach inside while it's running. Just this once I won't wait for the moving parts to stop. Experience makes you confident. Confidence makes you careless.", "image": "img/s14-just-this-once.jpg" },
+    
+    { "type": "list", "label": "The Six Steps", "heading": "Every time. In order.", "items": [
+      { "num": "1.", "text": "<strong>Prepare:</strong> Review procedure, notify affected employees" },
+      { "num": "2.", "text": "<strong>Shutdown:</strong> Use normal stopping procedures, verify zero motion" },
+      { "num": "3.", "text": "<strong>Isolate:</strong> Disconnect from all energy sources" },
+      { "num": "4.", "text": "<strong>Lock:</strong> Apply lockout devices, one per person" },
+      { "num": "5.", "text": "<strong>Stored Energy:</strong> Relieve, disconnect, or restrain" },
+      { "num": "6.", "text": "<strong>Verify:</strong> Test that equipment cannot operate" }
+    ], "image": "img/s15-six-steps-complete.jpg" },
+    
+    { "type": "summary", "heading": "Module 2 — Key Concepts", "items": [
+      "A lock is a fact, a sign is a request",
+      "Six steps create six layers of protection",
+      "One person, one lock — your lock protects your life", 
+      "Tags inform, locks prevent — use both",
+      "Experience creates dangerous shortcuts",
+      "Every accident starts with 'just this once'",
+      "Everyone goes home safe"
+    ] }
+  ],
+
+  "quiz": [
+    {
+      "question": "What's the difference between a sign and a lock in LOTO procedures?",
+      "options": [
+        "Signs are permanent, locks are temporary",
+        "Signs inform about hazards, locks prevent operation",
+        "Signs are for electrical, locks are for mechanical",
+        "There is no difference — they serve the same purpose"
+      ],
+      "correct": 1
+    },
+    {
+      "question": "Why is the 'Prepare for Shutdown' step important?",
+      "options": [
+        "It's required paperwork for legal compliance",
+        "It identifies all energy sources and lockout points before work begins",
+        "It delays the job to ensure workers are paid more",
+        "It's only necessary for new employees"
+      ],
+      "correct": 1
+    },
+    {
+      "question": "In the 'One Person, One Lock' principle, when can you remove someone else's lock?",
+      "options": [
+        "When they give you permission",
+        "When you're the supervisor",
+        "When their shift ends",
+        "Never — each person removes only their own lock"
+      ],
+      "correct": 3
+    },
+    {
+      "question": "According to the module, who is most likely to skip LOTO procedures?",
+      "options": [
+        "New employees who don't know better",
+        "Experienced workers who think they know the equipment",
+        "Workers who don't have proper training",
+        "Employees working on simple tasks"
+      ],
+      "correct": 1
+    }
+  ]
+}

--- a/courses/loto/builds/module-02/img/.gitkeep
+++ b/courses/loto/builds/module-02/img/.gitkeep
@@ -1,0 +1,1 @@
+# Images for LOTO Module 2

--- a/courses/loto/builds/module-02/index.html
+++ b/courses/loto/builds/module-02/index.html
@@ -1,0 +1,1159 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Module 2: The Six Steps | SOPs Nobody Reads</title>
+<style>
+/* ============================================
+   SOPs Nobody Reads — Module Player
+   Aesthetic: Industrial Safety / OSHA Training
+   Industrial theme: Steel, safety yellow, warning red
+   ============================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@300;400;600;700&family=Source+Sans+Pro:ital,wght@0,400;0,600;0,700;1,400&family=Inter:wght@400;500;600&display=swap');
+
+:root {
+  --bg-dark: #1a1a1a;
+  --bg-card: #2a2a2a;
+  --bg-warm: #333333;
+  --steel: #e5e7eb;
+  --steel-dim: #9ca3af;
+  --safety-yellow: #fbbf24;
+  --warning-red: #ef4444;
+  --caution-orange: #f59e0b;
+  --steel-blue: #64748b;
+  --steel-blue-light: #94a3b8;
+  --success-green: #10b981;
+  --dark-red: #7f1d1d;
+  --dark-green: #14532d;
+  --charcoal: #374151;
+  --font-display: 'Roboto Slab', Georgia, serif;
+  --font-body: 'Source Sans Pro', 'Segoe UI', sans-serif;
+  --font-ui: 'Inter', 'Segoe UI', sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg-dark);
+  color: var(--steel);
+}
+
+.grain {
+  position: fixed;
+  top: -50%; left: -50%;
+  width: 200%; height: 200%;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: 0.04;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.95' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  animation: grainShift 0.8s steps(4) infinite;
+}
+@keyframes grainShift {
+  0% { transform: translate(0, 0); }
+  25% { transform: translate(-2%, -1%); }
+  50% { transform: translate(1%, 2%); }
+  75% { transform: translate(-1%, -2%); }
+  100% { transform: translate(2%, 1%); }
+}
+
+.vignette {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9998;
+  background: radial-gradient(ellipse at center, transparent 50%, rgba(0,0,0,0.4) 100%);
+}
+
+.player {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-body);
+}
+
+.slide-container {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
+
+.slide {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 4vh 8vw;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+  pointer-events: none;
+  background-color: var(--bg-dark);
+}
+.slide.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* --- Background image support --- */
+.slide.has-image {
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.slide.has-image::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: radial-gradient(ellipse at center,
+    rgba(26,26,26,0.6) 0%,
+    rgba(26,26,26,0.82) 100%);
+}
+
+.slide-scene.has-image::before {
+  background: radial-gradient(ellipse at center,
+    rgba(26,26,26,0.68) 0%,
+    rgba(26,26,26,0.88) 100%);
+}
+
+.slide-concept.has-image::before {
+  background: radial-gradient(ellipse at center,
+    rgba(26,26,26,0.65) 0%,
+    rgba(26,26,26,0.85) 100%);
+}
+
+.slide-options.has-image::before {
+  background: radial-gradient(ellipse at center,
+    rgba(26,26,26,0.58) 0%,
+    rgba(26,26,26,0.82) 100%);
+}
+
+.slide-list.has-image::before {
+  background: radial-gradient(ellipse at center,
+    rgba(26,26,26,0.65) 0%,
+    rgba(26,26,26,0.85) 100%);
+}
+
+.slide.has-image > * {
+  position: relative;
+  z-index: 2;
+}
+
+/* --- Slide type styles --- */
+
+.slide-title {
+  text-align: center;
+  background: linear-gradient(170deg, var(--bg-warm) 0%, var(--bg-dark) 100%);
+}
+.slide-title .module-label {
+  font-family: var(--font-ui);
+  font-size: clamp(0.7rem, 1.2vw, 0.9rem);
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: var(--safety-yellow);
+  margin-bottom: 2vh;
+  font-weight: 600;
+}
+.slide-title h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 5vw, 4.5rem);
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--steel);
+  margin-bottom: 2vh;
+}
+.slide-title .subtitle {
+  font-family: var(--font-body);
+  font-size: clamp(0.9rem, 1.8vw, 1.3rem);
+  color: var(--steel-dim);
+  font-style: italic;
+  font-weight: 400;
+}
+.slide-title .brand {
+  position: absolute;
+  bottom: 4vh;
+  font-family: var(--font-ui);
+  font-size: 0.7rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--steel-blue);
+}
+
+.slide-scene {
+  text-align: center;
+  background: linear-gradient(170deg, #2a2a2a 0%, var(--bg-dark) 100%);
+}
+.slide-scene .scene-label {
+  font-family: var(--font-ui);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--caution-orange);
+  margin-bottom: 1vh;
+}
+.slide-scene p {
+  font-size: clamp(1.1rem, 2.2vw, 1.8rem);
+  line-height: 1.4;
+  color: var(--steel);
+  max-width: 65vw;
+  font-style: italic;
+}
+.slide-scene em {
+  color: var(--warning-red);
+  font-weight: 600;
+  font-style: normal;
+}
+
+.slide-keypoint {
+  text-align: center;
+  background: linear-gradient(170deg, #222 0%, var(--bg-dark) 100%);
+}
+.slide-keypoint .kicker {
+  font-family: var(--font-ui);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--safety-yellow);
+  margin-bottom: 2vh;
+  font-weight: 600;
+}
+.slide-keypoint h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 4.5vw, 3.5rem);
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--steel);
+  margin-bottom: 3vh;
+  max-width: 80vw;
+}
+.slide-keypoint .body {
+  font-size: clamp(0.95rem, 1.8vw, 1.25rem);
+  line-height: 1.5;
+  color: var(--steel-dim);
+  max-width: 70vw;
+}
+
+.slide-reveal {
+  text-align: center;
+  background: linear-gradient(170deg, var(--bg-warm) 0%, var(--bg-dark) 100%);
+}
+.slide-reveal .kicker {
+  font-family: var(--font-ui);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--safety-yellow);
+  margin-bottom: 2vh;
+  font-weight: 600;
+}
+.slide-reveal h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 4.5vw, 3.5rem);
+  font-weight: 700;
+  line-height: 1.15;
+  color: var(--steel);
+  margin-bottom: 3vh;
+  max-width: 80vw;
+}
+.slide-reveal .body {
+  font-size: clamp(1rem, 2vw, 1.4rem);
+  line-height: 1.4;
+  color: var(--steel-blue);
+  max-width: 65vw;
+  font-style: italic;
+}
+
+.slide-concept {
+  text-align: center;
+  background: linear-gradient(170deg, #1e1e1e 0%, var(--bg-dark) 100%);
+}
+.slide-concept .concept-label {
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--safety-yellow);
+  margin-bottom: 3vh;
+  font-weight: 600;
+}
+.slide-concept .concept-box {
+  background: var(--charcoal);
+  border: 2px solid var(--safety-yellow);
+  border-radius: 8px;
+  padding: 2.5vh 3vw;
+  margin: 0 auto 3vh;
+  max-width: 75vw;
+}
+.slide-concept .box-text {
+  font-size: clamp(1.1rem, 2.2vw, 1.6rem);
+  line-height: 1.4;
+  color: var(--steel);
+  font-weight: 600;
+}
+.slide-concept .body {
+  font-size: clamp(0.9rem, 1.7vw, 1.2rem);
+  line-height: 1.5;
+  color: var(--steel-dim);
+  max-width: 70vw;
+}
+
+.slide-list {
+  padding-left: 10vw;
+  background: linear-gradient(170deg, #1e1e1e 0%, var(--bg-dark) 100%);
+}
+.slide-list .list-label {
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--safety-yellow);
+  margin-bottom: 2vh;
+  font-weight: 600;
+}
+.slide-list h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.6rem, 3.5vw, 2.8rem);
+  font-weight: 700;
+  color: var(--steel);
+  margin-bottom: 4vh;
+  line-height: 1.2;
+}
+.slide-list .list-items {
+  list-style: none;
+}
+.slide-list .list-item {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 2.5vh;
+  max-width: 70vw;
+}
+.slide-list .item-num {
+  font-family: var(--font-ui);
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--safety-yellow);
+  margin-right: 1.5vw;
+  min-width: 2rem;
+}
+.slide-list .item-text {
+  font-size: clamp(0.9rem, 1.7vw, 1.2rem);
+  line-height: 1.5;
+  color: var(--steel-dim);
+}
+.slide-list strong {
+  color: var(--steel);
+  font-weight: 600;
+}
+
+.slide-summary {
+  text-align: center;
+  background: linear-gradient(170deg, var(--bg-warm) 0%, var(--bg-dark) 100%);
+}
+.slide-summary h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.5rem, 3.2vw, 2.5rem);
+  font-weight: 700;
+  color: var(--steel);
+  margin-bottom: 4vh;
+  line-height: 1.2;
+}
+.slide-summary .summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5vh;
+  max-width: 80vw;
+}
+.slide-summary .summary-item {
+  font-size: clamp(0.85rem, 1.5vw, 1.1rem);
+  line-height: 1.4;
+  color: var(--steel-dim);
+  text-align: left;
+  padding: 0.5vh 0;
+}
+.slide-summary .summary-item::before {
+  content: "—";
+  color: var(--safety-yellow);
+  margin-right: 0.5em;
+  font-weight: 600;
+}
+
+.slide-options {
+  text-align: center;
+  background: linear-gradient(170deg, #222 0%, var(--bg-dark) 100%);
+}
+.slide-options h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.4rem, 3vw, 2.3rem);
+  font-weight: 700;
+  color: var(--steel);
+  margin-bottom: 4vh;
+  line-height: 1.3;
+  max-width: 80vw;
+}
+.slide-options .options-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2vh;
+  max-width: 75vw;
+}
+.slide-options .option {
+  display: flex;
+  align-items: center;
+  background: var(--bg-card);
+  border: 2px solid transparent;
+  border-radius: 8px;
+  padding: 2vh 2.5vw;
+  text-align: left;
+  transition: all 0.3s ease;
+}
+.slide-options .option.highlighted {
+  border-color: var(--safety-yellow);
+  background: rgba(251, 191, 36, 0.1);
+}
+.slide-options .option-letter {
+  font-family: var(--font-ui);
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--safety-yellow);
+  background: var(--charcoal);
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 2vw;
+  flex-shrink: 0;
+}
+.slide-options .option-content h3 {
+  font-size: clamp(0.95rem, 1.8vw, 1.3rem);
+  font-weight: 600;
+  color: var(--steel);
+  margin-bottom: 0.5vh;
+}
+.slide-options .option-content p {
+  font-size: clamp(0.8rem, 1.5vw, 1.1rem);
+  line-height: 1.4;
+  color: var(--steel-dim);
+}
+
+/* --- Bottom Bar --- */
+
+.bottom-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5vh 3vw;
+  background: var(--charcoal);
+  border-top: 1px solid var(--steel-blue);
+  font-family: var(--font-ui);
+}
+
+.nav-btn {
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--steel);
+  background: transparent;
+  border: 1px solid var(--steel-blue);
+  border-radius: 4px;
+  padding: 0.8rem 1.2rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-decoration: none;
+  display: inline-block;
+}
+.nav-btn:hover:not(:disabled) {
+  background: var(--safety-yellow);
+  color: var(--bg-dark);
+  border-color: var(--safety-yellow);
+}
+.nav-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.progress-section {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.progress-track {
+  width: 200px;
+  height: 6px;
+  background: var(--bg-dark);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.progress-fill {
+  height: 100%;
+  background: var(--safety-yellow);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+  width: 0%;
+}
+.progress-text {
+  font-size: 0.8rem;
+  color: var(--steel-dim);
+  min-width: 4rem;
+  text-align: center;
+}
+
+.nav-buttons {
+  display: flex;
+  gap: 1rem;
+}
+
+/* --- Quiz Styles --- */
+
+.quiz-container {
+  text-align: center;
+  max-width: 80vw;
+}
+.quiz-container h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.4rem, 3vw, 2.3rem);
+  font-weight: 700;
+  color: var(--steel);
+  margin-bottom: 4vh;
+  line-height: 1.3;
+}
+.quiz-options {
+  display: flex;
+  flex-direction: column;
+  gap: 2vh;
+  margin-bottom: 3vh;
+}
+.quiz-option {
+  display: flex;
+  align-items: center;
+  background: var(--bg-card);
+  border: 2px solid transparent;
+  border-radius: 8px;
+  padding: 2vh 2.5vw;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+.quiz-option:hover {
+  border-color: var(--steel-blue);
+}
+.quiz-option.selected {
+  border-color: var(--safety-yellow);
+  background: rgba(251, 191, 36, 0.1);
+}
+.quiz-option.correct {
+  border-color: var(--success-green);
+  background: rgba(16, 185, 129, 0.1);
+}
+.quiz-option.incorrect {
+  border-color: var(--warning-red);
+  background: rgba(239, 68, 68, 0.1);
+  opacity: 0.6;
+}
+.quiz-option .option-letter {
+  font-family: var(--font-ui);
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--safety-yellow);
+  background: var(--charcoal);
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 2vw;
+  flex-shrink: 0;
+}
+.quiz-option.correct .option-letter {
+  background: var(--success-green);
+  color: white;
+}
+.quiz-option.incorrect .option-letter {
+  background: var(--warning-red);
+  color: white;
+}
+.quiz-option .option-text {
+  font-size: clamp(0.9rem, 1.7vw, 1.2rem);
+  line-height: 1.4;
+  color: var(--steel);
+}
+
+.quiz-feedback {
+  font-size: clamp(0.85rem, 1.5vw, 1.1rem);
+  line-height: 1.4;
+  color: var(--steel-dim);
+  margin-top: 2vh;
+  padding: 2vh;
+  background: var(--bg-card);
+  border-radius: 6px;
+  border-left: 4px solid var(--safety-yellow);
+}
+
+/* Results slide */
+.results-container {
+  text-align: center;
+  max-width: 70vw;
+}
+.results-container h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 4vw, 3rem);
+  font-weight: 700;
+  color: var(--steel);
+  margin-bottom: 3vh;
+}
+.score-display {
+  font-size: clamp(2rem, 5vw, 4rem);
+  font-weight: 700;
+  margin: 3vh 0;
+}
+.score-display.pass {
+  color: var(--success-green);
+}
+.score-display.fail {
+  color: var(--warning-red);
+}
+.results-message {
+  font-size: clamp(1rem, 2vw, 1.4rem);
+  line-height: 1.4;
+  color: var(--steel-dim);
+  margin-bottom: 4vh;
+}
+.results-actions {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+.results-actions .nav-btn {
+  min-width: 8rem;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .slide {
+    padding: 3vh 5vw;
+  }
+  .progress-track {
+    width: 120px;
+  }
+  .nav-buttons {
+    gap: 0.5rem;
+  }
+  .nav-btn {
+    font-size: 0.75rem;
+    padding: 0.6rem 0.8rem;
+  }
+  .slide-options .options-container,
+  .quiz-options {
+    max-width: 90vw;
+  }
+}
+
+@media (max-width: 480px) {
+  .slide {
+    padding: 2vh 4vw;
+  }
+  .bottom-bar {
+    padding: 1vh 2vw;
+  }
+  .progress-section {
+    gap: 0.5rem;
+  }
+  .progress-track {
+    width: 80px;
+  }
+}
+</style>
+</head>
+
+<body>
+<div class="grain"></div>
+<div class="vignette"></div>
+
+<div class="player" id="player">
+  <div class="slide-container" id="slideContainer"></div>
+
+  <div class="bottom-bar">
+    <a href="../index.html" class="nav-btn" style="margin-right: 2vw;">MENU</a>
+    <div class="progress-section">
+      <div class="progress-track">
+        <div class="progress-fill" id="progressFill"></div>
+      </div>
+      <span class="progress-text" id="progressText">1 / 1</span>
+    </div>
+    <div class="nav-buttons">
+      <button class="nav-btn" id="prevBtn" disabled>&#8592; Prev</button>
+      <button class="nav-btn" id="nextBtn">Next &#8594;</button>
+    </div>
+  </div>
+</div>
+
+<script>
+const MODULE = {
+  "title": "The Six Steps", 
+  "moduleNumber": 2,
+  "partLabel": "Part Two — The Procedure That Keeps You Alive",
+  "passingScore": 75,
+  "slides": [
+    { "type": "title", "moduleLabel": "Module 2", "heading": "The Six Steps", "subtitle": "Part Two — The Procedure That Keeps You Alive", "brand": "SOPs Nobody Reads" },
+    { "type": "scene", "label": "Cold Open", "text": "A breaker panel in a hallway. Someone has taped a handwritten sign next to one of the breakers: <em>\"DO NOT TURN ON — Mike working on Line 3.\"</em> The tape is peeling at one corner.", "image": "img/s01-handwritten-sign.jpg" },
+    { "type": "scene", "label": "Scene", "text": "A hand reaches past the sign and flips the breaker to ON. The sign flutters. The hand belongs to someone who didn't read it, or didn't think it applied to them.", "image": "img/s02-flips-breaker.jpg" },
+    { "type": "reveal", "kicker": "The Difference", "heading": "A sign is not a lock.\nA sign is a request.\nA lock is a fact.", "body": "And the difference between a request and a fact is the distance between going home tonight and not.", "image": "img/s03-sign-vs-lock.jpg" },
+    { "type": "keypoint", "kicker": "Why Order Matters", "heading": "Six steps.\nSix layers of protection.", "body": "Each step handles something the previous step couldn't. Skip a layer and there's a gap. A gap in this process is a gap in your protection.", "image": "img/s04-six-steps.jpg" },
+    { "type": "keypoint", "kicker": "Step 1", "heading": "Prepare for Shutdown", "body": "Find the machine-specific lockout procedure. Know what you're dealing with. Notify affected employees. This isn't paperwork — it's your map. Without it, you're guessing.", "image": "img/s05-prepare.jpg" },
+    { "type": "keypoint", "kicker": "Step 2", "heading": "Equipment Shutdown", "body": "Use normal stopping procedures. Verify all moving parts have actually stopped — not almost stopped, not slowing down. Stopped. Flywheels coast. Wait for zero.", "image": "img/s06-shutdown.jpg" },
+    { "type": "keypoint", "kicker": "Step 3", "heading": "Energy Isolation", "body": "Disconnect from every energy source. Electric, pneumatic, hydraulic, mechanical. Turn breakers to OFF. Close valves. Disconnect supply lines. Isolation means no energy can reach the equipment.", "image": "img/s07-isolate.jpg" },
+    { "type": "keypoint", "kicker": "Step 4", "heading": "Apply Lockout Devices", "body": "Lock every isolation point. One lock per person working on the equipment. Your lock, your key, your life. Remove only your own locks when your work is complete.", "image": "img/s08-lockout.jpg" },
+    { "type": "keypoint", "kicker": "Step 5", "heading": "Stored Energy Control", "body": "Relieve, disconnect, or restrain stored energy. Bleed air pressure. Discharge capacitors. Support suspended components. Release spring tension safely. Stored energy is patient — it waits.", "image": "img/s09-stored-energy.jpg" },
+    { "type": "keypoint", "kicker": "Step 6", "heading": "Verify Isolation", "body": "Test that the equipment cannot be operated. Try to start it using normal procedures. Check for movement, lights, sounds. Verify zero energy state before beginning work.", "image": "img/s10-verify.jpg" },
+    { "type": "concept", "label": "One Person, One Lock", "boxText": "Each worker applies their own lock and removes only their own lock.", "body": "Your lock protects you. Someone else's lock protects them. You never remove another person's lock. They never remove yours. This isn't bureaucracy — it's survival.", "image": "img/s11-one-person-one-lock.jpg" },
+    { "type": "concept", "label": "Tags vs. Locks", "boxText": "Tags inform. Locks prevent. Tags supplement locks — they never replace them.", "body": "A tag tells you who's working and why. But a tag won't stop someone from flipping a switch. Use both: lock to prevent, tag to inform.", "image": "img/s12-tags-vs-locks.jpg" },
+    { "type": "keypoint", "kicker": "Why People Skip Steps", "heading": "\"I've done this job\na hundred times.\"", "body": "Experience creates shortcuts. Familiarity breeds assumption. The worker who skips LOTO is usually the experienced one — the one who knows the machine, knows the work, knows it'll only take five minutes.", "image": "img/s13-experienced-worker.jpg" },
+    { "type": "reveal", "kicker": "The Psychology", "heading": "Every accident starts\nwith \"just this once.\"", "body": "Just this once I'll skip the lockout. Just this once I'll reach inside while it's running. Just this once I won't wait for the moving parts to stop. Experience makes you confident. Confidence makes you careless.", "image": "img/s14-just-this-once.jpg" },
+    { "type": "list", "label": "The Six Steps", "heading": "Every time. In order.", "items": [
+      { "num": "1.", "text": "<strong>Prepare:</strong> Review procedure, notify affected employees" },
+      { "num": "2.", "text": "<strong>Shutdown:</strong> Use normal stopping procedures, verify zero motion" },
+      { "num": "3.", "text": "<strong>Isolate:</strong> Disconnect from all energy sources" },
+      { "num": "4.", "text": "<strong>Lock:</strong> Apply lockout devices, one per person" },
+      { "num": "5.", "text": "<strong>Stored Energy:</strong> Relieve, disconnect, or restrain" },
+      { "num": "6.", "text": "<strong>Verify:</strong> Test that equipment cannot operate" }
+    ], "image": "img/s15-six-steps-complete.jpg" },
+    { "type": "summary", "heading": "Module 2 — Key Concepts", "items": [
+      "A lock is a fact, a sign is a request",
+      "Six steps create six layers of protection",
+      "One person, one lock — your lock protects your life", 
+      "Tags inform, locks prevent — use both",
+      "Experience creates dangerous shortcuts",
+      "Every accident starts with 'just this once'",
+      "Everyone goes home safe"
+    ] }
+  ],
+  "quiz": [
+    {
+      "question": "What's the difference between a sign and a lock in LOTO procedures?",
+      "options": [
+        "Signs are permanent, locks are temporary",
+        "Signs inform about hazards, locks prevent operation",
+        "Signs are for electrical, locks are for mechanical",
+        "There is no difference — they serve the same purpose"
+      ],
+      "correct": 1
+    },
+    {
+      "question": "Why is the 'Prepare for Shutdown' step important?",
+      "options": [
+        "It's required paperwork for legal compliance",
+        "It identifies all energy sources and lockout points before work begins",
+        "It delays the job to ensure workers are paid more",
+        "It's only necessary for new employees"
+      ],
+      "correct": 1
+    },
+    {
+      "question": "In the 'One Person, One Lock' principle, when can you remove someone else's lock?",
+      "options": [
+        "When they give you permission",
+        "When you're the supervisor",
+        "When their shift ends",
+        "Never — each person removes only their own lock"
+      ],
+      "correct": 3
+    },
+    {
+      "question": "According to the module, who is most likely to skip LOTO procedures?",
+      "options": [
+        "New employees who don't know better",
+        "Experienced workers who think they know the equipment",
+        "Workers who don't have proper training",
+        "Employees working on simple tasks"
+      ],
+      "correct": 1
+    }
+  ]
+};
+
+// Player JavaScript (same as Module 1, no modifications needed)
+let currentSlide = 0;
+let quizAnswers = [];
+let quizMode = false;
+let currentQuizQuestion = 0;
+let isAnswered = false;
+
+function initPlayer() {
+  renderSlide();
+  updateProgress();
+  updateNavButtons();
+}
+
+function renderSlide() {
+  const container = document.getElementById('slideContainer');
+  
+  if (quizMode) {
+    renderQuiz();
+    return;
+  }
+  
+  const slide = MODULE.slides[currentSlide];
+  if (!slide) return;
+  
+  let html = '';
+  let slideClasses = `slide slide-${slide.type}`;
+  
+  if (slide.image) {
+    slideClasses += ' has-image';
+  }
+  
+  switch (slide.type) {
+    case 'title':
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <div class="module-label">${slide.moduleLabel}</div>
+          <h1>${slide.heading.replace(/\\n/g, '<br>')}</h1>
+          <div class="subtitle">${slide.subtitle}</div>
+          <div class="brand">${slide.brand}</div>
+        </div>
+      `;
+      break;
+      
+    case 'scene':
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <div class="scene-label">${slide.label}</div>
+          <p>${slide.text}</p>
+        </div>
+      `;
+      break;
+      
+    case 'keypoint':
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          ${slide.kicker ? `<div class="kicker">${slide.kicker}</div>` : ''}
+          <h2>${slide.heading.replace(/\\n/g, '<br>')}</h2>
+          <div class="body">${slide.body}</div>
+        </div>
+      `;
+      break;
+      
+    case 'reveal':
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <div class="kicker">${slide.kicker}</div>
+          <h2>${slide.heading.replace(/\\n/g, '<br>')}</h2>
+          <div class="body">${slide.body}</div>
+        </div>
+      `;
+      break;
+      
+    case 'concept':
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <div class="concept-label">${slide.label}</div>
+          <div class="concept-box">
+            <div class="box-text">${slide.boxText}</div>
+          </div>
+          <div class="body">${slide.body}</div>
+        </div>
+      `;
+      break;
+      
+    case 'list':
+      const listItems = slide.items.map(item => `
+        <div class="list-item">
+          <div class="item-num">${item.num}</div>
+          <div class="item-text">${item.text}</div>
+        </div>
+      `).join('');
+      
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <div class="list-label">${slide.label}</div>
+          <h2>${slide.heading}</h2>
+          <div class="list-items">
+            ${listItems}
+          </div>
+        </div>
+      `;
+      break;
+      
+    case 'summary':
+      const summaryItems = slide.items.map(item => `
+        <div class="summary-item">${item}</div>
+      `).join('');
+      
+      html = `
+        <div class="${slideClasses}">
+          <h2>${slide.heading}</h2>
+          <div class="summary-grid">
+            ${summaryItems}
+          </div>
+        </div>
+      `;
+      break;
+      
+    case 'options':
+      const options = slide.options.map(option => `
+        <div class="option ${slide.highlighted === option.letter ? 'highlighted' : ''}">
+          <div class="option-letter">${option.letter}</div>
+          <div class="option-content">
+            <h3>${option.title}</h3>
+            <p>${option.desc}</p>
+          </div>
+        </div>
+      `).join('');
+      
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <h2>${slide.heading}</h2>
+          <div class="options-container">
+            ${options}
+          </div>
+        </div>
+      `;
+      break;
+  }
+  
+  container.innerHTML = html;
+  
+  // Activate the slide
+  setTimeout(() => {
+    const slideEl = container.querySelector('.slide');
+    if (slideEl) slideEl.classList.add('active');
+  }, 50);
+}
+
+function renderQuiz() {
+  const container = document.getElementById('slideContainer');
+  
+  if (currentQuizQuestion >= MODULE.quiz.length) {
+    renderResults();
+    return;
+  }
+  
+  const question = MODULE.quiz[currentQuizQuestion];
+  const options = question.options.map((option, index) => {
+    const letter = String.fromCharCode(65 + index);
+    let classes = 'quiz-option';
+    
+    if (isAnswered) {
+      if (index === question.correct) {
+        classes += ' correct';
+      } else if (quizAnswers[currentQuizQuestion] === index) {
+        classes += ' incorrect';
+      }
+    } else if (quizAnswers[currentQuizQuestion] === index) {
+      classes += ' selected';
+    }
+    
+    return `
+      <div class="${classes}" onclick="${!isAnswered ? `selectAnswer(${index})` : ''}">
+        <div class="option-letter">${letter}</div>
+        <div class="option-text">${option}</div>
+      </div>
+    `;
+  }).join('');
+  
+  let feedback = '';
+  if (isAnswered) {
+    const isCorrect = quizAnswers[currentQuizQuestion] === question.correct;
+    feedback = `
+      <div class="quiz-feedback">
+        ${isCorrect ? 'Correct!' : 'Incorrect.'} ${getQuizFeedback(currentQuizQuestion)}
+      </div>
+    `;
+  }
+  
+  const html = `
+    <div class="slide slide-quiz active">
+      <div class="quiz-container">
+        <h2>Question ${currentQuizQuestion + 1}</h2>
+        <p style="margin-bottom: 3vh; color: var(--steel-dim); font-size: clamp(1rem, 2vw, 1.3rem);">
+          ${question.question}
+        </p>
+        <div class="quiz-options">
+          ${options}
+        </div>
+        ${feedback}
+      </div>
+    </div>
+  `;
+  
+  container.innerHTML = html;
+}
+
+function selectAnswer(answerIndex) {
+  if (isAnswered) return;
+  
+  quizAnswers[currentQuizQuestion] = answerIndex;
+  isAnswered = true;
+  renderQuiz();
+  updateNavButtons();
+}
+
+function getQuizFeedback(questionIndex) {
+  const feedbacks = [
+    "Signs inform about hazards, while locks physically prevent operation of equipment.",
+    "The Prepare step identifies all energy sources and lockout points before work begins, providing a safety map.",
+    "In the 'One Person, One Lock' principle, each person removes only their own lock to maintain individual protection.",
+    "Experienced workers are most likely to skip procedures due to overconfidence and familiarity with equipment."
+  ];
+  return feedbacks[questionIndex] || '';
+}
+
+function renderResults() {
+  const container = document.getElementById('slideContainer');
+  const correctAnswers = quizAnswers.filter((answer, index) => answer === MODULE.quiz[index].correct).length;
+  const totalQuestions = MODULE.quiz.length;
+  const percentage = Math.round((correctAnswers / totalQuestions) * 100);
+  const passed = percentage >= MODULE.passingScore;
+  
+  const html = `
+    <div class="slide slide-results active">
+      <div class="results-container">
+        <h2>Module ${MODULE.moduleNumber} Complete</h2>
+        <div class="score-display ${passed ? 'pass' : 'fail'}">
+          ${percentage}%
+        </div>
+        <div class="results-message">
+          ${correctAnswers} of ${totalQuestions} questions correct<br>
+          ${passed ? 'You passed! Well done.' : `You need ${MODULE.passingScore}% to pass. Please review the material and try again.`}
+        </div>
+        <div class="results-actions">
+          ${!passed ? `<button class="nav-btn" onclick="restartQuiz()">Try Again</button>` : ''}
+          <a href="../module-03/index.html" class="nav-btn">Next Module &#8594;</a>
+        </div>
+        <p style="margin-top: 3vh; font-size: 0.9rem; color: var(--steel-dim);">
+          Module 2 of 3 &mdash; Continue to the final module on complex LOTO situations.
+        </p>
+      </div>
+    </div>
+  `;
+  
+  container.innerHTML = html;
+}
+
+function restartQuiz() {
+  quizAnswers = [];
+  currentQuizQuestion = 0;
+  isAnswered = false;
+  renderQuiz();
+  updateNavButtons();
+}
+
+function nextSlide() {
+  if (quizMode) {
+    if (isAnswered) {
+      if (currentQuizQuestion < MODULE.quiz.length - 1) {
+        currentQuizQuestion++;
+        isAnswered = false;
+        renderQuiz();
+      } else {
+        renderResults();
+      }
+    }
+  } else {
+    if (currentSlide < MODULE.slides.length - 1) {
+      currentSlide++;
+      renderSlide();
+    } else {
+      // Start quiz
+      quizMode = true;
+      currentQuizQuestion = 0;
+      isAnswered = false;
+      renderQuiz();
+    }
+  }
+  
+  updateProgress();
+  updateNavButtons();
+}
+
+function prevSlide() {
+  if (quizMode && currentQuizQuestion === 0) {
+    quizMode = false;
+    currentSlide = MODULE.slides.length - 1;
+    renderSlide();
+  } else if (quizMode) {
+    currentQuizQuestion--;
+    isAnswered = quizAnswers[currentQuizQuestion] !== undefined;
+    renderQuiz();
+  } else if (currentSlide > 0) {
+    currentSlide--;
+    renderSlide();
+  }
+  
+  updateProgress();
+  updateNavButtons();
+}
+
+function updateProgress() {
+  const totalSlides = MODULE.slides.length + MODULE.quiz.length;
+  const currentPos = quizMode ? MODULE.slides.length + currentQuizQuestion + 1 : currentSlide + 1;
+  const percentage = (currentPos / totalSlides) * 100;
+  
+  document.getElementById('progressFill').style.width = `${percentage}%`;
+  document.getElementById('progressText').textContent = `${currentPos} / ${totalSlides}`;
+}
+
+function updateNavButtons() {
+  const prevBtn = document.getElementById('prevBtn');
+  const nextBtn = document.getElementById('nextBtn');
+  
+  prevBtn.disabled = (!quizMode && currentSlide === 0) || (quizMode && currentQuizQuestion === 0 && currentSlide === 0);
+  
+  if (quizMode) {
+    nextBtn.disabled = !isAnswered;
+    if (currentQuizQuestion >= MODULE.quiz.length - 1 && isAnswered) {
+      nextBtn.textContent = 'Results ►';
+    } else {
+      nextBtn.textContent = 'Next ►';
+    }
+  } else {
+    nextBtn.disabled = false;
+    if (currentSlide === MODULE.slides.length - 1) {
+      nextBtn.textContent = 'Quiz ►';
+    } else {
+      nextBtn.textContent = 'Next ►';
+    }
+  }
+}
+
+// Event listeners
+document.getElementById('prevBtn').addEventListener('click', prevSlide);
+document.getElementById('nextBtn').addEventListener('click', nextSlide);
+
+// Keyboard navigation
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'ArrowRight' && !document.getElementById('nextBtn').disabled) {
+    nextSlide();
+  } else if (e.key === 'ArrowLeft' && !document.getElementById('prevBtn').disabled) {
+    prevSlide();
+  }
+});
+
+// Initialize player
+initPlayer();
+
+// SCORM API stubs (graceful degradation)
+window.API = window.API || {
+  LMSInitialize: () => 'true',
+  LMSCommit: () => 'true', 
+  LMSFinish: () => 'true',
+  LMSGetValue: () => '',
+  LMSSetValue: () => 'true',
+  LMSGetLastError: () => '0',
+  LMSGetErrorString: () => '',
+  LMSGetDiagnostic: () => ''
+};
+</script>
+</body>
+</html>

--- a/courses/loto/builds/module-03.json
+++ b/courses/loto/builds/module-03.json
@@ -1,0 +1,101 @@
+{
+  "title": "When Simple Gets Complicated",
+  "moduleNumber": 3, 
+  "partLabel": "Part Three — The Edge Cases",
+  "passingScore": 75,
+
+  "slides": [
+    { "type": "title", "moduleLabel": "Module 3", "heading": "When Simple\nGets Complicated", "subtitle": "Part Three — The Edge Cases", "brand": "SOPs Nobody Reads" },
+    
+    { "type": "scene", "label": "Cold Open", "text": "Shift change. The outgoing crew walks toward the exit. One of them pulls a lock off a disconnect on their way out. Casual. Done for the day.", "image": "img/s01-shift-change.jpg" },
+    
+    { "type": "scene", "label": "Scene", "text": "The disconnect has no lock now. The incoming crew is still in the break room getting briefed. For the next four minutes, this machine is unprotected.", "image": "img/s02-gap-in-protection.jpg" },
+    
+    { "type": "reveal", "kicker": "The Gap", "heading": "Four minutes.\nThat's the gap between\none crew's safety and the next.", "body": "And in that gap, anyone could start this machine. Shift change creates vulnerability unless managed properly.", "image": "img/s03-four-minutes.jpg" },
+    
+    { "type": "keypoint", "kicker": "Restoring Equipment", "heading": "Seven steps to\nbring it back safely", "body": "You've locked the machine out. You've done the work. Now it's time to restore the equipment. This has its own sequence, and it matters as much as the lockout itself.", "image": "img/s04-seven-steps.jpg" },
+    
+    { "type": "list", "label": "Restoration Steps", "heading": "In this order. Every time.", "items": [
+      { "num": "1.", "text": "<strong>Inspect:</strong> Work is finished, all tools accounted for" },
+      { "num": "2.", "text": "<strong>Clean up:</strong> Parts, rags, work aids back where they belong" },
+      { "num": "3.", "text": "<strong>Replace guards:</strong> Every guard back before machine starts" },
+      { "num": "4.", "text": "<strong>Check controls:</strong> Everything in neutral or safest position" },
+      { "num": "5.", "text": "<strong>Check for personnel:</strong> All workers verified clear and notified" },
+      { "num": "6.", "text": "<strong>Remove your lock:</strong> Only your lock. Not someone else's." },
+      { "num": "7.", "text": "<strong>Re-energize:</strong> Follow manufacturer's startup procedures" }
+    ], "image": "img/s05-restoration-checklist.jpg" },
+    
+    { "type": "concept", "label": "Check for Personnel", "boxText": "This is not a glance. This is a headcount.", "body": "If three people were working on this machine, three people must be verified clear before any lock comes off. Every person who was working must be accounted for and notified.", "image": "img/s06-headcount.jpg" },
+    
+    { "type": "keypoint", "kicker": "Group Lockout", "heading": "Multiple workers,\nmultiple locks", "body": "When multiple workers need to service the same equipment, each one applies their own lock. The principle scales: one person, one lock. The machine cannot restart until the last lock is off.", "image": "img/s07-multiple-locks.jpg" },
+    
+    { "type": "concept", "label": "Group Coordinator", "boxText": "Someone needs to be in charge. One authorized employee manages the overall lockout.", "body": "They don't replace individual locks. They organize the process, review procedures with everyone, and coordinate the work.", "image": "img/s08-coordinator.jpg" },
+    
+    { "type": "keypoint", "kicker": "Lockbox Method", "heading": "What if there's only\nroom for one lock?", "body": "One lock goes on the disconnect. The key to that lock goes inside a lockbox. Each worker puts their own lock on the lockbox. The machine can't start until every worker removes their lock from the box.", "image": "img/s09-lockbox-method.jpg" },
+    
+    { "type": "keypoint", "kicker": "Shift Change Protocol", "heading": "Continuous protection\nacross shift changes", "body": "The incoming crew applies their locks before the outgoing crew removes theirs. Overlap protection. The machine is never unprotected, not even for minutes.", "image": "img/s10-shift-overlap.jpg" },
+    
+    { "type": "keypoint", "kicker": "Emergency Lock Removal", "heading": "When someone leaves\ntheir lock behind", "body": "This requires special authorization. The absent employee must be contacted and verified. Management approval required. All affected personnel notified. This is not a casual decision.", "image": "img/s11-emergency-removal.jpg" },
+    
+    { "type": "concept", "label": "Roles and Responsibility", "boxText": "Authorized employee: Can apply and remove locks, coordinate group lockout. Affected employee: Notified of lockout, must stay clear.", "body": "Each role has specific responsibilities. Know which role you're in for each lockout situation. Authority matters. Clear communication matters.", "image": "img/s12-roles.jpg" },
+    
+    { "type": "keypoint", "kicker": "The Paperwork Reframe", "heading": "Documentation isn't\nbureaucracy", "body": "It's memory. Who's working where. What energy sources are controlled. When the work started. When it ended. When someone gets hurt, this documentation explains what went right and what went wrong.", "image": "img/s13-documentation.jpg" },
+    
+    { "type": "reveal", "kicker": "The Complete Picture", "heading": "LOTO isn't just\na six-step procedure", "body": "It's a comprehensive system. Individual lockout. Group lockout. Shift change protocols. Emergency procedures. Documentation. Each element protects against specific failure modes.", "image": "img/s14-complete-system.jpg" },
+    
+    { "type": "keypoint", "kicker": "Course Complete", "heading": "You now understand\nthe energy you don't see", "body": "Five types of hazardous energy. Six steps to control them. Protocols for complex situations. The tools to protect yourself and your coworkers. Two minutes and a padlock. That's all it takes.", "image": "img/s15-course-complete.jpg" },
+    
+    { "type": "summary", "heading": "LOTO Course — Key Concepts", "items": [
+      "LOTO is a comprehensive system, not just a procedure",
+      "Group lockout scales the one-person-one-lock principle",
+      "Lockbox method handles single-lock situations", 
+      "Shift change requires overlap protection",
+      "Emergency lock removal needs special authorization",
+      "Documentation provides memory and accountability",
+      "Everyone goes home safe — every shift, every day"
+    ] }
+  ],
+
+  "quiz": [
+    {
+      "question": "In group lockout situations with multiple workers, how many locks should be applied?",
+      "options": [
+        "One lock controlled by the supervisor",
+        "Two locks — one for electrical, one for mechanical",
+        "One lock per person working on the equipment",
+        "The minimum number required to secure all energy sources"
+      ],
+      "correct": 2
+    },
+    {
+      "question": "What is the lockbox method used for?",
+      "options": [
+        "Storing extra padlocks for future use",
+        "When multiple workers need lockout but only one lock fits the disconnect",
+        "Emergency storage of critical equipment keys",
+        "Group lockout situations with more than 5 workers"
+      ],
+      "correct": 1
+    },
+    {
+      "question": "During shift change, when should the incoming crew apply their locks?",
+      "options": [
+        "After the outgoing crew removes all their locks",
+        "Before the outgoing crew removes their locks (overlap protection)",
+        "Only if work will continue into the next shift",
+        "At the supervisor's discretion"
+      ],
+      "correct": 1
+    },
+    {
+      "question": "What step comes immediately before removing locks during equipment restoration?",
+      "options": [
+        "Clean up the work area",
+        "Replace all machine guards",
+        "Check for personnel — verify all workers are clear",
+        "Re-energize the equipment"
+      ],
+      "correct": 2
+    }
+  ]
+}

--- a/courses/loto/builds/module-03/img/.gitkeep
+++ b/courses/loto/builds/module-03/img/.gitkeep
@@ -1,0 +1,1 @@
+# Images for LOTO Module 3

--- a/courses/loto/builds/module-03/index.html
+++ b/courses/loto/builds/module-03/index.html
@@ -1,0 +1,1190 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Module 3: When Simple Gets Complicated | SOPs Nobody Reads</title>
+<style>
+/* ============================================
+   SOPs Nobody Reads — Module Player
+   Aesthetic: Industrial Safety / OSHA Training
+   Industrial theme: Steel, safety yellow, warning red
+   ============================================ */
+
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Slab:wght@300;400;600;700&family=Source+Sans+Pro:ital,wght@0,400;0,600;0,700;1,400&family=Inter:wght@400;500;600&display=swap');
+
+:root {
+  --bg-dark: #1a1a1a;
+  --bg-card: #2a2a2a;
+  --bg-warm: #333333;
+  --steel: #e5e7eb;
+  --steel-dim: #9ca3af;
+  --safety-yellow: #fbbf24;
+  --warning-red: #ef4444;
+  --caution-orange: #f59e0b;
+  --steel-blue: #64748b;
+  --steel-blue-light: #94a3b8;
+  --success-green: #10b981;
+  --dark-red: #7f1d1d;
+  --dark-green: #14532d;
+  --charcoal: #374151;
+  --font-display: 'Roboto Slab', Georgia, serif;
+  --font-body: 'Source Sans Pro', 'Segoe UI', sans-serif;
+  --font-ui: 'Inter', 'Segoe UI', sans-serif;
+}
+
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+html, body {
+  height: 100%;
+  overflow: hidden;
+  background: var(--bg-dark);
+  color: var(--steel);
+}
+
+.grain {
+  position: fixed;
+  top: -50%; left: -50%;
+  width: 200%; height: 200%;
+  pointer-events: none;
+  z-index: 9999;
+  opacity: 0.04;
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.95' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  animation: grainShift 0.8s steps(4) infinite;
+}
+@keyframes grainShift {
+  0% { transform: translate(0, 0); }
+  25% { transform: translate(-2%, -1%); }
+  50% { transform: translate(1%, 2%); }
+  75% { transform: translate(-1%, -2%); }
+  100% { transform: translate(2%, 1%); }
+}
+
+.vignette {
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  z-index: 9998;
+  background: radial-gradient(ellipse at center, transparent 50%, rgba(0,0,0,0.4) 100%);
+}
+
+.player {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  font-family: var(--font-body);
+}
+
+.slide-container {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
+
+.slide {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 4vh 8vw;
+  opacity: 0;
+  transition: opacity 0.6s ease;
+  pointer-events: none;
+  background-color: var(--bg-dark);
+}
+.slide.active {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+/* --- Background image support --- */
+.slide.has-image {
+  background-size: cover;
+  background-position: center;
+  background-repeat: no-repeat;
+}
+
+.slide.has-image::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  z-index: 1;
+  background: radial-gradient(ellipse at center,
+    rgba(26,26,26,0.6) 0%,
+    rgba(26,26,26,0.82) 100%);
+}
+
+.slide-scene.has-image::before {
+  background: radial-gradient(ellipse at center,
+    rgba(26,26,26,0.68) 0%,
+    rgba(26,26,26,0.88) 100%);
+}
+
+.slide-concept.has-image::before {
+  background: radial-gradient(ellipse at center,
+    rgba(26,26,26,0.65) 0%,
+    rgba(26,26,26,0.85) 100%);
+}
+
+.slide-options.has-image::before {
+  background: radial-gradient(ellipse at center,
+    rgba(26,26,26,0.58) 0%,
+    rgba(26,26,26,0.82) 100%);
+}
+
+.slide-list.has-image::before {
+  background: radial-gradient(ellipse at center,
+    rgba(26,26,26,0.65) 0%,
+    rgba(26,26,26,0.85) 100%);
+}
+
+.slide.has-image > * {
+  position: relative;
+  z-index: 2;
+}
+
+/* --- Slide type styles --- */
+
+.slide-title {
+  text-align: center;
+  background: linear-gradient(170deg, var(--bg-warm) 0%, var(--bg-dark) 100%);
+}
+.slide-title .module-label {
+  font-family: var(--font-ui);
+  font-size: clamp(0.7rem, 1.2vw, 0.9rem);
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  color: var(--safety-yellow);
+  margin-bottom: 2vh;
+  font-weight: 600;
+}
+.slide-title h1 {
+  font-family: var(--font-display);
+  font-size: clamp(2rem, 5vw, 4.5rem);
+  font-weight: 700;
+  line-height: 1.1;
+  color: var(--steel);
+  margin-bottom: 2vh;
+}
+.slide-title .subtitle {
+  font-family: var(--font-body);
+  font-size: clamp(0.9rem, 1.8vw, 1.3rem);
+  color: var(--steel-dim);
+  font-style: italic;
+  font-weight: 400;
+}
+.slide-title .brand {
+  position: absolute;
+  bottom: 4vh;
+  font-family: var(--font-ui);
+  font-size: 0.7rem;
+  letter-spacing: 0.25em;
+  text-transform: uppercase;
+  color: var(--steel-blue);
+}
+
+.slide-scene {
+  text-align: center;
+  background: linear-gradient(170deg, #2a2a2a 0%, var(--bg-dark) 100%);
+}
+.slide-scene .scene-label {
+  font-family: var(--font-ui);
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--caution-orange);
+  margin-bottom: 1vh;
+}
+.slide-scene p {
+  font-size: clamp(1.1rem, 2.2vw, 1.8rem);
+  line-height: 1.4;
+  color: var(--steel);
+  max-width: 65vw;
+  font-style: italic;
+}
+.slide-scene em {
+  color: var(--warning-red);
+  font-weight: 600;
+  font-style: normal;
+}
+
+.slide-keypoint {
+  text-align: center;
+  background: linear-gradient(170deg, #222 0%, var(--bg-dark) 100%);
+}
+.slide-keypoint .kicker {
+  font-family: var(--font-ui);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--safety-yellow);
+  margin-bottom: 2vh;
+  font-weight: 600;
+}
+.slide-keypoint h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 4.5vw, 3.5rem);
+  font-weight: 700;
+  line-height: 1.2;
+  color: var(--steel);
+  margin-bottom: 3vh;
+  max-width: 80vw;
+}
+.slide-keypoint .body {
+  font-size: clamp(0.95rem, 1.8vw, 1.25rem);
+  line-height: 1.5;
+  color: var(--steel-dim);
+  max-width: 70vw;
+}
+
+.slide-reveal {
+  text-align: center;
+  background: linear-gradient(170deg, var(--bg-warm) 0%, var(--bg-dark) 100%);
+}
+.slide-reveal .kicker {
+  font-family: var(--font-ui);
+  font-size: 0.9rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--safety-yellow);
+  margin-bottom: 2vh;
+  font-weight: 600;
+}
+.slide-reveal h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 4.5vw, 3.5rem);
+  font-weight: 700;
+  line-height: 1.15;
+  color: var(--steel);
+  margin-bottom: 3vh;
+  max-width: 80vw;
+}
+.slide-reveal .body {
+  font-size: clamp(1rem, 2vw, 1.4rem);
+  line-height: 1.4;
+  color: var(--steel-blue);
+  max-width: 65vw;
+  font-style: italic;
+}
+
+.slide-concept {
+  text-align: center;
+  background: linear-gradient(170deg, #1e1e1e 0%, var(--bg-dark) 100%);
+}
+.slide-concept .concept-label {
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--safety-yellow);
+  margin-bottom: 3vh;
+  font-weight: 600;
+}
+.slide-concept .concept-box {
+  background: var(--charcoal);
+  border: 2px solid var(--safety-yellow);
+  border-radius: 8px;
+  padding: 2.5vh 3vw;
+  margin: 0 auto 3vh;
+  max-width: 75vw;
+}
+.slide-concept .box-text {
+  font-size: clamp(1.1rem, 2.2vw, 1.6rem);
+  line-height: 1.4;
+  color: var(--steel);
+  font-weight: 600;
+}
+.slide-concept .body {
+  font-size: clamp(0.9rem, 1.7vw, 1.2rem);
+  line-height: 1.5;
+  color: var(--steel-dim);
+  max-width: 70vw;
+}
+
+.slide-list {
+  padding-left: 10vw;
+  background: linear-gradient(170deg, #1e1e1e 0%, var(--bg-dark) 100%);
+}
+.slide-list .list-label {
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--safety-yellow);
+  margin-bottom: 2vh;
+  font-weight: 600;
+}
+.slide-list h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.6rem, 3.5vw, 2.8rem);
+  font-weight: 700;
+  color: var(--steel);
+  margin-bottom: 4vh;
+  line-height: 1.2;
+}
+.slide-list .list-items {
+  list-style: none;
+}
+.slide-list .list-item {
+  display: flex;
+  align-items: flex-start;
+  margin-bottom: 2.5vh;
+  max-width: 70vw;
+}
+.slide-list .item-num {
+  font-family: var(--font-ui);
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--safety-yellow);
+  margin-right: 1.5vw;
+  min-width: 2rem;
+}
+.slide-list .item-text {
+  font-size: clamp(0.9rem, 1.7vw, 1.2rem);
+  line-height: 1.5;
+  color: var(--steel-dim);
+}
+.slide-list strong {
+  color: var(--steel);
+  font-weight: 600;
+}
+
+.slide-summary {
+  text-align: center;
+  background: linear-gradient(170deg, var(--bg-warm) 0%, var(--bg-dark) 100%);
+}
+.slide-summary h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.5rem, 3.2vw, 2.5rem);
+  font-weight: 700;
+  color: var(--steel);
+  margin-bottom: 4vh;
+  line-height: 1.2;
+}
+.slide-summary .summary-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1.5vh;
+  max-width: 80vw;
+}
+.slide-summary .summary-item {
+  font-size: clamp(0.85rem, 1.5vw, 1.1rem);
+  line-height: 1.4;
+  color: var(--steel-dim);
+  text-align: left;
+  padding: 0.5vh 0;
+}
+.slide-summary .summary-item::before {
+  content: "—";
+  color: var(--safety-yellow);
+  margin-right: 0.5em;
+  font-weight: 600;
+}
+
+.slide-options {
+  text-align: center;
+  background: linear-gradient(170deg, #222 0%, var(--bg-dark) 100%);
+}
+.slide-options h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.4rem, 3vw, 2.3rem);
+  font-weight: 700;
+  color: var(--steel);
+  margin-bottom: 4vh;
+  line-height: 1.3;
+  max-width: 80vw;
+}
+.slide-options .options-container {
+  display: flex;
+  flex-direction: column;
+  gap: 2vh;
+  max-width: 75vw;
+}
+.slide-options .option {
+  display: flex;
+  align-items: center;
+  background: var(--bg-card);
+  border: 2px solid transparent;
+  border-radius: 8px;
+  padding: 2vh 2.5vw;
+  text-align: left;
+  transition: all 0.3s ease;
+}
+.slide-options .option.highlighted {
+  border-color: var(--safety-yellow);
+  background: rgba(251, 191, 36, 0.1);
+}
+.slide-options .option-letter {
+  font-family: var(--font-ui);
+  font-size: 1.2rem;
+  font-weight: 700;
+  color: var(--safety-yellow);
+  background: var(--charcoal);
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 2vw;
+  flex-shrink: 0;
+}
+.slide-options .option-content h3 {
+  font-size: clamp(0.95rem, 1.8vw, 1.3rem);
+  font-weight: 600;
+  color: var(--steel);
+  margin-bottom: 0.5vh;
+}
+.slide-options .option-content p {
+  font-size: clamp(0.8rem, 1.5vw, 1.1rem);
+  line-height: 1.4;
+  color: var(--steel-dim);
+}
+
+/* --- Bottom Bar --- */
+
+.bottom-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.5vh 3vw;
+  background: var(--charcoal);
+  border-top: 1px solid var(--steel-blue);
+  font-family: var(--font-ui);
+}
+
+.nav-btn {
+  font-family: var(--font-ui);
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--steel);
+  background: transparent;
+  border: 1px solid var(--steel-blue);
+  border-radius: 4px;
+  padding: 0.8rem 1.2rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  text-decoration: none;
+  display: inline-block;
+}
+.nav-btn:hover:not(:disabled) {
+  background: var(--safety-yellow);
+  color: var(--bg-dark);
+  border-color: var(--safety-yellow);
+}
+.nav-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.progress-section {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.progress-track {
+  width: 200px;
+  height: 6px;
+  background: var(--bg-dark);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.progress-fill {
+  height: 100%;
+  background: var(--safety-yellow);
+  border-radius: 3px;
+  transition: width 0.3s ease;
+  width: 0%;
+}
+.progress-text {
+  font-size: 0.8rem;
+  color: var(--steel-dim);
+  min-width: 4rem;
+  text-align: center;
+}
+
+.nav-buttons {
+  display: flex;
+  gap: 1rem;
+}
+
+/* --- Quiz Styles --- */
+
+.quiz-container {
+  text-align: center;
+  max-width: 80vw;
+}
+.quiz-container h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.4rem, 3vw, 2.3rem);
+  font-weight: 700;
+  color: var(--steel);
+  margin-bottom: 4vh;
+  line-height: 1.3;
+}
+.quiz-options {
+  display: flex;
+  flex-direction: column;
+  gap: 2vh;
+  margin-bottom: 3vh;
+}
+.quiz-option {
+  display: flex;
+  align-items: center;
+  background: var(--bg-card);
+  border: 2px solid transparent;
+  border-radius: 8px;
+  padding: 2vh 2.5vw;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.3s ease;
+}
+.quiz-option:hover {
+  border-color: var(--steel-blue);
+}
+.quiz-option.selected {
+  border-color: var(--safety-yellow);
+  background: rgba(251, 191, 36, 0.1);
+}
+.quiz-option.correct {
+  border-color: var(--success-green);
+  background: rgba(16, 185, 129, 0.1);
+}
+.quiz-option.incorrect {
+  border-color: var(--warning-red);
+  background: rgba(239, 68, 68, 0.1);
+  opacity: 0.6;
+}
+.quiz-option .option-letter {
+  font-family: var(--font-ui);
+  font-size: 1.1rem;
+  font-weight: 700;
+  color: var(--safety-yellow);
+  background: var(--charcoal);
+  width: 2.2rem;
+  height: 2.2rem;
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-right: 2vw;
+  flex-shrink: 0;
+}
+.quiz-option.correct .option-letter {
+  background: var(--success-green);
+  color: white;
+}
+.quiz-option.incorrect .option-letter {
+  background: var(--warning-red);
+  color: white;
+}
+.quiz-option .option-text {
+  font-size: clamp(0.9rem, 1.7vw, 1.2rem);
+  line-height: 1.4;
+  color: var(--steel);
+}
+
+.quiz-feedback {
+  font-size: clamp(0.85rem, 1.5vw, 1.1rem);
+  line-height: 1.4;
+  color: var(--steel-dim);
+  margin-top: 2vh;
+  padding: 2vh;
+  background: var(--bg-card);
+  border-radius: 6px;
+  border-left: 4px solid var(--safety-yellow);
+}
+
+/* Results slide */
+.results-container {
+  text-align: center;
+  max-width: 70vw;
+}
+.results-container h2 {
+  font-family: var(--font-display);
+  font-size: clamp(1.8rem, 4vw, 3rem);
+  font-weight: 700;
+  color: var(--steel);
+  margin-bottom: 3vh;
+}
+.score-display {
+  font-size: clamp(2rem, 5vw, 4rem);
+  font-weight: 700;
+  margin: 3vh 0;
+}
+.score-display.pass {
+  color: var(--success-green);
+}
+.score-display.fail {
+  color: var(--warning-red);
+}
+.results-message {
+  font-size: clamp(1rem, 2vw, 1.4rem);
+  line-height: 1.4;
+  color: var(--steel-dim);
+  margin-bottom: 4vh;
+}
+.results-actions {
+  display: flex;
+  justify-content: center;
+  gap: 2rem;
+  flex-wrap: wrap;
+}
+.results-actions .nav-btn {
+  min-width: 8rem;
+}
+
+/* Course Complete styles */
+.course-complete {
+  padding: 3vh;
+  background: var(--charcoal);
+  border-radius: 8px;
+  border: 2px solid var(--success-green);
+  margin: 3vh 0;
+}
+.course-complete h3 {
+  font-family: var(--font-display);
+  font-size: clamp(1.4rem, 2.8vw, 2rem);
+  color: var(--success-green);
+  margin-bottom: 2vh;
+}
+.course-complete p {
+  font-size: clamp(0.9rem, 1.6vw, 1.2rem);
+  line-height: 1.5;
+  color: var(--steel-dim);
+  margin-bottom: 1.5vh;
+}
+
+/* Responsive adjustments */
+@media (max-width: 768px) {
+  .slide {
+    padding: 3vh 5vw;
+  }
+  .progress-track {
+    width: 120px;
+  }
+  .nav-buttons {
+    gap: 0.5rem;
+  }
+  .nav-btn {
+    font-size: 0.75rem;
+    padding: 0.6rem 0.8rem;
+  }
+  .slide-options .options-container,
+  .quiz-options {
+    max-width: 90vw;
+  }
+}
+
+@media (max-width: 480px) {
+  .slide {
+    padding: 2vh 4vw;
+  }
+  .bottom-bar {
+    padding: 1vh 2vw;
+  }
+  .progress-section {
+    gap: 0.5rem;
+  }
+  .progress-track {
+    width: 80px;
+  }
+}
+</style>
+</head>
+
+<body>
+<div class="grain"></div>
+<div class="vignette"></div>
+
+<div class="player" id="player">
+  <div class="slide-container" id="slideContainer"></div>
+
+  <div class="bottom-bar">
+    <a href="../index.html" class="nav-btn" style="margin-right: 2vw;">MENU</a>
+    <div class="progress-section">
+      <div class="progress-track">
+        <div class="progress-fill" id="progressFill"></div>
+      </div>
+      <span class="progress-text" id="progressText">1 / 1</span>
+    </div>
+    <div class="nav-buttons">
+      <button class="nav-btn" id="prevBtn" disabled>&#8592; Prev</button>
+      <button class="nav-btn" id="nextBtn">Next &#8594;</button>
+    </div>
+  </div>
+</div>
+
+<script>
+const MODULE = {
+  "title": "When Simple Gets Complicated",
+  "moduleNumber": 3, 
+  "partLabel": "Part Three — The Edge Cases",
+  "passingScore": 75,
+  "slides": [
+    { "type": "title", "moduleLabel": "Module 3", "heading": "When Simple\nGets Complicated", "subtitle": "Part Three — The Edge Cases", "brand": "SOPs Nobody Reads" },
+    { "type": "scene", "label": "Cold Open", "text": "Shift change. The outgoing crew walks toward the exit. One of them pulls a lock off a disconnect on their way out. Casual. Done for the day.", "image": "img/s01-shift-change.jpg" },
+    { "type": "scene", "label": "Scene", "text": "The disconnect has no lock now. The incoming crew is still in the break room getting briefed. For the next four minutes, this machine is unprotected.", "image": "img/s02-gap-in-protection.jpg" },
+    { "type": "reveal", "kicker": "The Gap", "heading": "Four minutes.\nThat's the gap between\none crew's safety and the next.", "body": "And in that gap, anyone could start this machine. Shift change creates vulnerability unless managed properly.", "image": "img/s03-four-minutes.jpg" },
+    { "type": "keypoint", "kicker": "Restoring Equipment", "heading": "Seven steps to\nbring it back safely", "body": "You've locked the machine out. You've done the work. Now it's time to restore the equipment. This has its own sequence, and it matters as much as the lockout itself.", "image": "img/s04-seven-steps.jpg" },
+    { "type": "list", "label": "Restoration Steps", "heading": "In this order. Every time.", "items": [
+      { "num": "1.", "text": "<strong>Inspect:</strong> Work is finished, all tools accounted for" },
+      { "num": "2.", "text": "<strong>Clean up:</strong> Parts, rags, work aids back where they belong" },
+      { "num": "3.", "text": "<strong>Replace guards:</strong> Every guard back before machine starts" },
+      { "num": "4.", "text": "<strong>Check controls:</strong> Everything in neutral or safest position" },
+      { "num": "5.", "text": "<strong>Check for personnel:</strong> All workers verified clear and notified" },
+      { "num": "6.", "text": "<strong>Remove your lock:</strong> Only your lock. Not someone else's." },
+      { "num": "7.", "text": "<strong>Re-energize:</strong> Follow manufacturer's startup procedures" }
+    ], "image": "img/s05-restoration-checklist.jpg" },
+    { "type": "concept", "label": "Check for Personnel", "boxText": "This is not a glance. This is a headcount.", "body": "If three people were working on this machine, three people must be verified clear before any lock comes off. Every person who was working must be accounted for and notified.", "image": "img/s06-headcount.jpg" },
+    { "type": "keypoint", "kicker": "Group Lockout", "heading": "Multiple workers,\nmultiple locks", "body": "When multiple workers need to service the same equipment, each one applies their own lock. The principle scales: one person, one lock. The machine cannot restart until the last lock is off.", "image": "img/s07-multiple-locks.jpg" },
+    { "type": "concept", "label": "Group Coordinator", "boxText": "Someone needs to be in charge. One authorized employee manages the overall lockout.", "body": "They don't replace individual locks. They organize the process, review procedures with everyone, and coordinate the work.", "image": "img/s08-coordinator.jpg" },
+    { "type": "keypoint", "kicker": "Lockbox Method", "heading": "What if there's only\nroom for one lock?", "body": "One lock goes on the disconnect. The key to that lock goes inside a lockbox. Each worker puts their own lock on the lockbox. The machine can't start until every worker removes their lock from the box.", "image": "img/s09-lockbox-method.jpg" },
+    { "type": "keypoint", "kicker": "Shift Change Protocol", "heading": "Continuous protection\nacross shift changes", "body": "The incoming crew applies their locks before the outgoing crew removes theirs. Overlap protection. The machine is never unprotected, not even for minutes.", "image": "img/s10-shift-overlap.jpg" },
+    { "type": "keypoint", "kicker": "Emergency Lock Removal", "heading": "When someone leaves\ntheir lock behind", "body": "This requires special authorization. The absent employee must be contacted and verified. Management approval required. All affected personnel notified. This is not a casual decision.", "image": "img/s11-emergency-removal.jpg" },
+    { "type": "concept", "label": "Roles and Responsibility", "boxText": "Authorized employee: Can apply and remove locks, coordinate group lockout. Affected employee: Notified of lockout, must stay clear.", "body": "Each role has specific responsibilities. Know which role you're in for each lockout situation. Authority matters. Clear communication matters.", "image": "img/s12-roles.jpg" },
+    { "type": "keypoint", "kicker": "The Paperwork Reframe", "heading": "Documentation isn't\nbureaucracy", "body": "It's memory. Who's working where. What energy sources are controlled. When the work started. When it ended. When someone gets hurt, this documentation explains what went right and what went wrong.", "image": "img/s13-documentation.jpg" },
+    { "type": "reveal", "kicker": "The Complete Picture", "heading": "LOTO isn't just\na six-step procedure", "body": "It's a comprehensive system. Individual lockout. Group lockout. Shift change protocols. Emergency procedures. Documentation. Each element protects against specific failure modes.", "image": "img/s14-complete-system.jpg" },
+    { "type": "keypoint", "kicker": "Course Complete", "heading": "You now understand\nthe energy you don't see", "body": "Five types of hazardous energy. Six steps to control them. Protocols for complex situations. The tools to protect yourself and your coworkers. Two minutes and a padlock. That's all it takes.", "image": "img/s15-course-complete.jpg" },
+    { "type": "summary", "heading": "LOTO Course — Key Concepts", "items": [
+      "LOTO is a comprehensive system, not just a procedure",
+      "Group lockout scales the one-person-one-lock principle",
+      "Lockbox method handles single-lock situations", 
+      "Shift change requires overlap protection",
+      "Emergency lock removal needs special authorization",
+      "Documentation provides memory and accountability",
+      "Everyone goes home safe — every shift, every day"
+    ] }
+  ],
+  "quiz": [
+    {
+      "question": "In group lockout situations with multiple workers, how many locks should be applied?",
+      "options": [
+        "One lock controlled by the supervisor",
+        "Two locks — one for electrical, one for mechanical",
+        "One lock per person working on the equipment",
+        "The minimum number required to secure all energy sources"
+      ],
+      "correct": 2
+    },
+    {
+      "question": "What is the lockbox method used for?",
+      "options": [
+        "Storing extra padlocks for future use",
+        "When multiple workers need lockout but only one lock fits the disconnect",
+        "Emergency storage of critical equipment keys",
+        "Group lockout situations with more than 5 workers"
+      ],
+      "correct": 1
+    },
+    {
+      "question": "During shift change, when should the incoming crew apply their locks?",
+      "options": [
+        "After the outgoing crew removes all their locks",
+        "Before the outgoing crew removes their locks (overlap protection)",
+        "Only if work will continue into the next shift",
+        "At the supervisor's discretion"
+      ],
+      "correct": 1
+    },
+    {
+      "question": "What step comes immediately before removing locks during equipment restoration?",
+      "options": [
+        "Clean up the work area",
+        "Replace all machine guards",
+        "Check for personnel — verify all workers are clear",
+        "Re-energize the equipment"
+      ],
+      "correct": 2
+    }
+  ]
+};
+
+// Player JavaScript (modified for course completion)
+let currentSlide = 0;
+let quizAnswers = [];
+let quizMode = false;
+let currentQuizQuestion = 0;
+let isAnswered = false;
+
+function initPlayer() {
+  renderSlide();
+  updateProgress();
+  updateNavButtons();
+}
+
+function renderSlide() {
+  const container = document.getElementById('slideContainer');
+  
+  if (quizMode) {
+    renderQuiz();
+    return;
+  }
+  
+  const slide = MODULE.slides[currentSlide];
+  if (!slide) return;
+  
+  let html = '';
+  let slideClasses = `slide slide-${slide.type}`;
+  
+  if (slide.image) {
+    slideClasses += ' has-image';
+  }
+  
+  switch (slide.type) {
+    case 'title':
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <div class="module-label">${slide.moduleLabel}</div>
+          <h1>${slide.heading.replace(/\\n/g, '<br>')}</h1>
+          <div class="subtitle">${slide.subtitle}</div>
+          <div class="brand">${slide.brand}</div>
+        </div>
+      `;
+      break;
+      
+    case 'scene':
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <div class="scene-label">${slide.label}</div>
+          <p>${slide.text}</p>
+        </div>
+      `;
+      break;
+      
+    case 'keypoint':
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          ${slide.kicker ? `<div class="kicker">${slide.kicker}</div>` : ''}
+          <h2>${slide.heading.replace(/\\n/g, '<br>')}</h2>
+          <div class="body">${slide.body}</div>
+        </div>
+      `;
+      break;
+      
+    case 'reveal':
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <div class="kicker">${slide.kicker}</div>
+          <h2>${slide.heading.replace(/\\n/g, '<br>')}</h2>
+          <div class="body">${slide.body}</div>
+        </div>
+      `;
+      break;
+      
+    case 'concept':
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <div class="concept-label">${slide.label}</div>
+          <div class="concept-box">
+            <div class="box-text">${slide.boxText}</div>
+          </div>
+          <div class="body">${slide.body}</div>
+        </div>
+      `;
+      break;
+      
+    case 'list':
+      const listItems = slide.items.map(item => `
+        <div class="list-item">
+          <div class="item-num">${item.num}</div>
+          <div class="item-text">${item.text}</div>
+        </div>
+      `).join('');
+      
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <div class="list-label">${slide.label}</div>
+          <h2>${slide.heading}</h2>
+          <div class="list-items">
+            ${listItems}
+          </div>
+        </div>
+      `;
+      break;
+      
+    case 'summary':
+      const summaryItems = slide.items.map(item => `
+        <div class="summary-item">${item}</div>
+      `).join('');
+      
+      html = `
+        <div class="${slideClasses}">
+          <h2>${slide.heading}</h2>
+          <div class="summary-grid">
+            ${summaryItems}
+          </div>
+        </div>
+      `;
+      break;
+      
+    case 'options':
+      const options = slide.options.map(option => `
+        <div class="option ${slide.highlighted === option.letter ? 'highlighted' : ''}">
+          <div class="option-letter">${option.letter}</div>
+          <div class="option-content">
+            <h3>${option.title}</h3>
+            <p>${option.desc}</p>
+          </div>
+        </div>
+      `).join('');
+      
+      html = `
+        <div class="${slideClasses}" style="${slide.image ? `background-image: url('${slide.image}')` : ''}">
+          <h2>${slide.heading}</h2>
+          <div class="options-container">
+            ${options}
+          </div>
+        </div>
+      `;
+      break;
+  }
+  
+  container.innerHTML = html;
+  
+  // Activate the slide
+  setTimeout(() => {
+    const slideEl = container.querySelector('.slide');
+    if (slideEl) slideEl.classList.add('active');
+  }, 50);
+}
+
+function renderQuiz() {
+  const container = document.getElementById('slideContainer');
+  
+  if (currentQuizQuestion >= MODULE.quiz.length) {
+    renderResults();
+    return;
+  }
+  
+  const question = MODULE.quiz[currentQuizQuestion];
+  const options = question.options.map((option, index) => {
+    const letter = String.fromCharCode(65 + index);
+    let classes = 'quiz-option';
+    
+    if (isAnswered) {
+      if (index === question.correct) {
+        classes += ' correct';
+      } else if (quizAnswers[currentQuizQuestion] === index) {
+        classes += ' incorrect';
+      }
+    } else if (quizAnswers[currentQuizQuestion] === index) {
+      classes += ' selected';
+    }
+    
+    return `
+      <div class="${classes}" onclick="${!isAnswered ? `selectAnswer(${index})` : ''}">
+        <div class="option-letter">${letter}</div>
+        <div class="option-text">${option}</div>
+      </div>
+    `;
+  }).join('');
+  
+  let feedback = '';
+  if (isAnswered) {
+    const isCorrect = quizAnswers[currentQuizQuestion] === question.correct;
+    feedback = `
+      <div class="quiz-feedback">
+        ${isCorrect ? 'Correct!' : 'Incorrect.'} ${getQuizFeedback(currentQuizQuestion)}
+      </div>
+    `;
+  }
+  
+  const html = `
+    <div class="slide slide-quiz active">
+      <div class="quiz-container">
+        <h2>Question ${currentQuizQuestion + 1}</h2>
+        <p style="margin-bottom: 3vh; color: var(--steel-dim); font-size: clamp(1rem, 2vw, 1.3rem);">
+          ${question.question}
+        </p>
+        <div class="quiz-options">
+          ${options}
+        </div>
+        ${feedback}
+      </div>
+    </div>
+  `;
+  
+  container.innerHTML = html;
+}
+
+function selectAnswer(answerIndex) {
+  if (isAnswered) return;
+  
+  quizAnswers[currentQuizQuestion] = answerIndex;
+  isAnswered = true;
+  renderQuiz();
+  updateNavButtons();
+}
+
+function getQuizFeedback(questionIndex) {
+  const feedbacks = [
+    "In group lockout, each person working on the equipment applies their own lock for individual protection.",
+    "The lockbox method is used when multiple workers need lockout but only one lock fits the disconnect point.",
+    "Overlap protection means incoming crew applies locks before outgoing crew removes theirs, ensuring continuous protection.",
+    "Checking for personnel (headcount) is the critical step immediately before removing any locks during restoration."
+  ];
+  return feedbacks[questionIndex] || '';
+}
+
+function renderResults() {
+  const container = document.getElementById('slideContainer');
+  const correctAnswers = quizAnswers.filter((answer, index) => answer === MODULE.quiz[index].correct).length;
+  const totalQuestions = MODULE.quiz.length;
+  const percentage = Math.round((correctAnswers / totalQuestions) * 100);
+  const passed = percentage >= MODULE.passingScore;
+  
+  const html = `
+    <div class="slide slide-results active">
+      <div class="results-container">
+        <h2>Module ${MODULE.moduleNumber} Complete</h2>
+        <div class="score-display ${passed ? 'pass' : 'fail'}">
+          ${percentage}%
+        </div>
+        <div class="results-message">
+          ${correctAnswers} of ${totalQuestions} questions correct<br>
+          ${passed ? 'You passed! Well done.' : `You need ${MODULE.passingScore}% to pass. Please review the material and try again.`}
+        </div>
+        
+        ${passed ? `
+        <div class="course-complete">
+          <h3>🎉 LOTO Course Complete!</h3>
+          <p>You have completed all three modules of the Lockout/Tagout course. You now understand how to control hazardous energy and protect yourself and your coworkers.</p>
+          <p><strong>Remember:</strong> Two minutes and a padlock. That's all it takes to ensure everyone goes home safe.</p>
+        </div>
+        ` : ''}
+        
+        <div class="results-actions">
+          ${!passed ? `<button class="nav-btn" onclick="restartQuiz()">Try Again</button>` : ''}
+          <a href="../index.html" class="nav-btn">Course Menu</a>
+        </div>
+        <p style="margin-top: 3vh; font-size: 0.9rem; color: var(--steel-dim);">
+          ${passed ? 'Course Complete — All 3 modules finished successfully!' : 'Module 3 of 3 — Review the material and retake the quiz to complete the course.'}
+        </p>
+      </div>
+    </div>
+  `;
+  
+  container.innerHTML = html;
+}
+
+function restartQuiz() {
+  quizAnswers = [];
+  currentQuizQuestion = 0;
+  isAnswered = false;
+  renderQuiz();
+  updateNavButtons();
+}
+
+function nextSlide() {
+  if (quizMode) {
+    if (isAnswered) {
+      if (currentQuizQuestion < MODULE.quiz.length - 1) {
+        currentQuizQuestion++;
+        isAnswered = false;
+        renderQuiz();
+      } else {
+        renderResults();
+      }
+    }
+  } else {
+    if (currentSlide < MODULE.slides.length - 1) {
+      currentSlide++;
+      renderSlide();
+    } else {
+      // Start quiz
+      quizMode = true;
+      currentQuizQuestion = 0;
+      isAnswered = false;
+      renderQuiz();
+    }
+  }
+  
+  updateProgress();
+  updateNavButtons();
+}
+
+function prevSlide() {
+  if (quizMode && currentQuizQuestion === 0) {
+    quizMode = false;
+    currentSlide = MODULE.slides.length - 1;
+    renderSlide();
+  } else if (quizMode) {
+    currentQuizQuestion--;
+    isAnswered = quizAnswers[currentQuizQuestion] !== undefined;
+    renderQuiz();
+  } else if (currentSlide > 0) {
+    currentSlide--;
+    renderSlide();
+  }
+  
+  updateProgress();
+  updateNavButtons();
+}
+
+function updateProgress() {
+  const totalSlides = MODULE.slides.length + MODULE.quiz.length;
+  const currentPos = quizMode ? MODULE.slides.length + currentQuizQuestion + 1 : currentSlide + 1;
+  const percentage = (currentPos / totalSlides) * 100;
+  
+  document.getElementById('progressFill').style.width = `${percentage}%`;
+  document.getElementById('progressText').textContent = `${currentPos} / ${totalSlides}`;
+}
+
+function updateNavButtons() {
+  const prevBtn = document.getElementById('prevBtn');
+  const nextBtn = document.getElementById('nextBtn');
+  
+  prevBtn.disabled = (!quizMode && currentSlide === 0) || (quizMode && currentQuizQuestion === 0 && currentSlide === 0);
+  
+  if (quizMode) {
+    nextBtn.disabled = !isAnswered;
+    if (currentQuizQuestion >= MODULE.quiz.length - 1 && isAnswered) {
+      nextBtn.textContent = 'Results ►';
+    } else {
+      nextBtn.textContent = 'Next ►';
+    }
+  } else {
+    nextBtn.disabled = false;
+    if (currentSlide === MODULE.slides.length - 1) {
+      nextBtn.textContent = 'Quiz ►';
+    } else {
+      nextBtn.textContent = 'Next ►';
+    }
+  }
+}
+
+// Event listeners
+document.getElementById('prevBtn').addEventListener('click', prevSlide);
+document.getElementById('nextBtn').addEventListener('click', nextSlide);
+
+// Keyboard navigation
+document.addEventListener('keydown', (e) => {
+  if (e.key === 'ArrowRight' && !document.getElementById('nextBtn').disabled) {
+    nextSlide();
+  } else if (e.key === 'ArrowLeft' && !document.getElementById('prevBtn').disabled) {
+    prevSlide();
+  }
+});
+
+// Initialize player
+initPlayer();
+
+// SCORM API stubs (graceful degradation)
+window.API = window.API || {
+  LMSInitialize: () => 'true',
+  LMSCommit: () => 'true', 
+  LMSFinish: () => 'true',
+  LMSGetValue: () => '',
+  LMSSetValue: () => 'true',
+  LMSGetLastError: () => '0',
+  LMSGetErrorString: () => '',
+  LMSGetDiagnostic: () => ''
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
Closes #46

Builds Module 2 and 3 HTML players for the LOTO course using Industrial theme. Since the prerequisite files didn't exist, also created the complete builds directory structure and Module 1 template.

**Changes:**
- Create LOTO builds directory structure
- Add Module 1-3 JSON data decomposed from existing scripts
- Build Module 1 player as Industrial theme template
- Build Module 2 player with six-step LOTO procedure
- Build Module 3 player with course completion messaging
- Industrial theme: steel grays, safety yellow, warning red
- All modules include comprehensive quizzes and progress tracking

**Testing:**
- Verified all files created successfully
- Confirmed module numbers and metadata correct
- Validated Module 3 course completion flow

Generated with [Claude Code](https://claude.ai/code)