### PR TITLE
LOTO: Add text-shadow to body text for contrast over images (all 3 modules)

### DIFF
--- a/courses/loto/builds/module-01/index.html
+++ b/courses/loto/builds/module-01/index.html
@@ -673,6 +673,16 @@ html, body {
     width: 80px;
   }
 }
+
+/* Text shadow for body text over dark backgrounds */
+.slide-keypoint .body,
+.slide-reveal .body, 
+.slide-concept .body,
+.slide-scene p,
+.slide-list .item-text,
+.slide-concept .box-text {
+  text-shadow: 0 1px 8px rgba(0,0,0,0.6);
+}
 </style>
 </head>
 

--- a/courses/loto/builds/module-02/index.html
+++ b/courses/loto/builds/module-02/index.html
@@ -673,6 +673,16 @@ html, body {
     width: 80px;
   }
 }
+
+/* Text shadow for body text over dark backgrounds */
+.slide-keypoint .body,
+.slide-reveal .body, 
+.slide-concept .body,
+.slide-scene p,
+.slide-list .item-text,
+.slide-concept .box-text {
+  text-shadow: 0 1px 8px rgba(0,0,0,0.6);
+}
 </style>
 </head>
 

--- a/courses/loto/builds/module-03/index.html
+++ b/courses/loto/builds/module-03/index.html
@@ -694,6 +694,16 @@ html, body {
     width: 80px;
   }
 }
+
+/* Text shadow for body text over dark backgrounds */
+.slide-keypoint .body,
+.slide-reveal .body, 
+.slide-concept .body,
+.slide-scene p,
+.slide-list .item-text,
+.slide-concept .box-text {
+  text-shadow: 0 1px 8px rgba(0,0,0,0.6);
+}
 </style>
 </head>
 


### PR DESCRIPTION
Closes #52

Added text-shadow to improve readability of body text over dark background images in all three LOTO module players.

## Changes
- Added `text-shadow: 0 1px 8px rgba(0,0,0,0.6)` to body text elements
- Targets slide types: keypoint, reveal, concept, scene, and list body text
- Improves contrast of `var(--steel-dim)` text over Industrial theme backgrounds
- Applied to module-01, module-02, and module-03

Generated with [Claude Code](https://claude.ai/code)