### PR TITLE
LOTO: Add dark scrim behind text content for readability over images (all 3 modules)

### DIFF
--- a/courses/loto/builds/module-01/index.html
+++ b/courses/loto/builds/module-01/index.html
@@ -674,14 +674,97 @@ html, body {
   }
 }
 
-/* Text shadow for body text over dark backgrounds */
+/* Text shadow for body text over dark backgrounds - enhanced */
 .slide-keypoint .body,
 .slide-reveal .body, 
 .slide-concept .body,
 .slide-scene p,
 .slide-list .item-text,
 .slide-concept .box-text {
-  text-shadow: 0 1px 8px rgba(0,0,0,0.6);
+  text-shadow: 0 2px 12px rgba(0,0,0,0.8), 0 1px 3px rgba(0,0,0,0.9);
+}
+
+/* Dark scrim behind text content for readability over images */
+.slide.has-image .scene-label,
+.slide.has-image .scene-label + p {
+  background: linear-gradient(
+    to bottom,
+    rgba(10, 22, 40, 0.6) 0%,
+    rgba(10, 22, 40, 0.8) 100%
+  );
+  padding: 1.5rem 2.5rem;
+  border-radius: 8px;
+  backdrop-filter: blur(2px);
+  margin-bottom: 2vh;
+}
+
+.slide.has-image .scene-label + p {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* Keypoint and reveal slides - create unified content area */
+.slide-keypoint.has-image > *:not(.slide),
+.slide-reveal.has-image > *:not(.slide) {
+  background: linear-gradient(
+    to bottom,
+    rgba(10, 22, 40, 0.6) 0%,
+    rgba(10, 22, 40, 0.8) 100%
+  );
+  padding: 2rem 3rem;
+  border-radius: 8px;
+  backdrop-filter: blur(2px);
+  margin: 1vh auto;
+  display: block;
+  text-align: center;
+}
+
+.slide-keypoint.has-image .kicker,
+.slide-reveal.has-image .kicker {
+  margin-bottom: 2vh;
+  background: transparent;
+  padding: 0;
+}
+
+.slide-keypoint.has-image h2,
+.slide-reveal.has-image h2 {
+  margin-bottom: 3vh;
+  background: transparent;
+  padding: 0;
+}
+
+.slide-keypoint.has-image .body,
+.slide-reveal.has-image .body {
+  margin-bottom: 0;
+  background: transparent;
+  padding: 0;
+}
+
+/* Concept slides - wrap content but preserve concept-box styling */
+.slide-concept.has-image .concept-label,
+.slide-concept.has-image .concept-box,
+.slide-concept.has-image .body {
+  position: relative;
+  z-index: 3;
+}
+
+.slide-concept.has-image::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(80vw, 600px);
+  height: 70%;
+  background: linear-gradient(
+    to bottom,
+    rgba(10, 22, 40, 0.6) 0%,
+    rgba(10, 22, 40, 0.8) 100%
+  );
+  border-radius: 8px;
+  backdrop-filter: blur(2px);
+  z-index: 2;
+  pointer-events: none;
 }
 </style>
 </head>

--- a/courses/loto/builds/module-02/index.html
+++ b/courses/loto/builds/module-02/index.html
@@ -674,14 +674,97 @@ html, body {
   }
 }
 
-/* Text shadow for body text over dark backgrounds */
+/* Text shadow for body text over dark backgrounds - enhanced */
 .slide-keypoint .body,
 .slide-reveal .body, 
 .slide-concept .body,
 .slide-scene p,
 .slide-list .item-text,
 .slide-concept .box-text {
-  text-shadow: 0 1px 8px rgba(0,0,0,0.6);
+  text-shadow: 0 2px 12px rgba(0,0,0,0.8), 0 1px 3px rgba(0,0,0,0.9);
+}
+
+/* Dark scrim behind text content for readability over images */
+.slide.has-image .scene-label,
+.slide.has-image .scene-label + p {
+  background: linear-gradient(
+    to bottom,
+    rgba(10, 22, 40, 0.6) 0%,
+    rgba(10, 22, 40, 0.8) 100%
+  );
+  padding: 1.5rem 2.5rem;
+  border-radius: 8px;
+  backdrop-filter: blur(2px);
+  margin-bottom: 2vh;
+}
+
+.slide.has-image .scene-label + p {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* Keypoint and reveal slides - create unified content area */
+.slide-keypoint.has-image > *:not(.slide),
+.slide-reveal.has-image > *:not(.slide) {
+  background: linear-gradient(
+    to bottom,
+    rgba(10, 22, 40, 0.6) 0%,
+    rgba(10, 22, 40, 0.8) 100%
+  );
+  padding: 2rem 3rem;
+  border-radius: 8px;
+  backdrop-filter: blur(2px);
+  margin: 1vh auto;
+  display: block;
+  text-align: center;
+}
+
+.slide-keypoint.has-image .kicker,
+.slide-reveal.has-image .kicker {
+  margin-bottom: 2vh;
+  background: transparent;
+  padding: 0;
+}
+
+.slide-keypoint.has-image h2,
+.slide-reveal.has-image h2 {
+  margin-bottom: 3vh;
+  background: transparent;
+  padding: 0;
+}
+
+.slide-keypoint.has-image .body,
+.slide-reveal.has-image .body {
+  margin-bottom: 0;
+  background: transparent;
+  padding: 0;
+}
+
+/* Concept slides - wrap content but preserve concept-box styling */
+.slide-concept.has-image .concept-label,
+.slide-concept.has-image .concept-box,
+.slide-concept.has-image .body {
+  position: relative;
+  z-index: 3;
+}
+
+.slide-concept.has-image::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(80vw, 600px);
+  height: 70%;
+  background: linear-gradient(
+    to bottom,
+    rgba(10, 22, 40, 0.6) 0%,
+    rgba(10, 22, 40, 0.8) 100%
+  );
+  border-radius: 8px;
+  backdrop-filter: blur(2px);
+  z-index: 2;
+  pointer-events: none;
 }
 </style>
 </head>

--- a/courses/loto/builds/module-03/index.html
+++ b/courses/loto/builds/module-03/index.html
@@ -695,14 +695,97 @@ html, body {
   }
 }
 
-/* Text shadow for body text over dark backgrounds */
+/* Text shadow for body text over dark backgrounds - enhanced */
 .slide-keypoint .body,
 .slide-reveal .body, 
 .slide-concept .body,
 .slide-scene p,
 .slide-list .item-text,
 .slide-concept .box-text {
-  text-shadow: 0 1px 8px rgba(0,0,0,0.6);
+  text-shadow: 0 2px 12px rgba(0,0,0,0.8), 0 1px 3px rgba(0,0,0,0.9);
+}
+
+/* Dark scrim behind text content for readability over images */
+.slide.has-image .scene-label,
+.slide.has-image .scene-label + p {
+  background: linear-gradient(
+    to bottom,
+    rgba(10, 22, 40, 0.6) 0%,
+    rgba(10, 22, 40, 0.8) 100%
+  );
+  padding: 1.5rem 2.5rem;
+  border-radius: 8px;
+  backdrop-filter: blur(2px);
+  margin-bottom: 2vh;
+}
+
+.slide.has-image .scene-label + p {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+/* Keypoint and reveal slides - create unified content area */
+.slide-keypoint.has-image > *:not(.slide),
+.slide-reveal.has-image > *:not(.slide) {
+  background: linear-gradient(
+    to bottom,
+    rgba(10, 22, 40, 0.6) 0%,
+    rgba(10, 22, 40, 0.8) 100%
+  );
+  padding: 2rem 3rem;
+  border-radius: 8px;
+  backdrop-filter: blur(2px);
+  margin: 1vh auto;
+  display: block;
+  text-align: center;
+}
+
+.slide-keypoint.has-image .kicker,
+.slide-reveal.has-image .kicker {
+  margin-bottom: 2vh;
+  background: transparent;
+  padding: 0;
+}
+
+.slide-keypoint.has-image h2,
+.slide-reveal.has-image h2 {
+  margin-bottom: 3vh;
+  background: transparent;
+  padding: 0;
+}
+
+.slide-keypoint.has-image .body,
+.slide-reveal.has-image .body {
+  margin-bottom: 0;
+  background: transparent;
+  padding: 0;
+}
+
+/* Concept slides - wrap content but preserve concept-box styling */
+.slide-concept.has-image .concept-label,
+.slide-concept.has-image .concept-box,
+.slide-concept.has-image .body {
+  position: relative;
+  z-index: 3;
+}
+
+.slide-concept.has-image::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(80vw, 600px);
+  height: 70%;
+  background: linear-gradient(
+    to bottom,
+    rgba(10, 22, 40, 0.6) 0%,
+    rgba(10, 22, 40, 0.8) 100%
+  );
+  border-radius: 8px;
+  backdrop-filter: blur(2px);
+  z-index: 2;
+  pointer-events: none;
 }
 </style>
 </head>


### PR DESCRIPTION
Closes #54

Added semi-transparent dark gradient overlays behind text content on image-backed slides for improved readability and accessibility.

**Changes:**
- Enhanced text-shadow with double shadow for maximum readability
- Added dark scrim using rgba(10, 22, 40, 0.6-0.8) gradient
- Applied to all image-backed slide types: scene, keypoint, reveal, concept
- Includes backdrop-filter blur and rounded corners
- Preserves existing styling while improving color-blind accessibility

**Files Modified:**
- courses/loto/builds/module-01/index.html
- courses/loto/builds/module-02/index.html
- courses/loto/builds/module-03/index.html

Generated with [Claude Code](https://claude.ai/code)