### PR TITLE
Phase 1.1: reconcile Movement B / STORED ENERGY redundancy

### DIFF
--- a/courses/loto/scripts/module-01-the-energy-you-dont-see.md
+++ b/courses/loto/scripts/module-01-the-energy-you-dont-see.md
@@ -241,7 +241,7 @@ It was off. It wasn't safe.
 ## STORED ENERGY
 
 **NARRATOR (V.O.):**
-This is the concept that matters most in this entire course, and it's the one most people skip past.
+Here's the definition underneath everything you just saw.
 
 **Stored energy** is the energy that remains in a system after you've isolated it from its source.
 
@@ -256,7 +256,7 @@ This is the concept that matters most in this entire course, and it's the one mo
 **NARRATOR (V.O.):**
 You closed the valve. Good. New energy can't enter the line.
 
-But the energy that was already in the line? It's still there. The fluid is still pressurized. The spring is still compressed. The capacitor is still charged. The load is still suspended.
+But the energy that was already in the line? It's still there. The fluid is still pressurized.
 
 Isolation stops new energy from entering. It doesn't remove the energy that's already present.
 
@@ -278,7 +278,7 @@ Prepare. Shut down. Isolate. Lock. Address stored energy. Verify.
 
 Most people, if they do anything at all, jump straight to step four. Slap a lock on the breaker. Feel safe.
 
-But without step one, they don't know all the energy sources. Without step two, they may not have stopped the machine properly. Without step three, they've only locked one source out of five. Without step five, the energy already in the system is still there. Without step six, they have no confirmation that any of it worked.
+But without step one, they don't know all the energy sources. Without step two, they may not have stopped the machine properly. Without step three, they've only locked one source out of six. Without step five, the energy already in the system is still there. Without step six, they have no confirmation that any of it worked.
 
 *[Beat.]*
 


### PR DESCRIPTION
## Summary
Follow-up to #61 (merged before this branch was cut, so this is a new PR rather than an amend). Reconciles the redundancy the Phase 1 refactor introduced: Movement B and the downstream STORED ENERGY section both claimed primacy and both recited the same four stored-energy examples ~40 lines apart.

- **STORED ENERGY** now: drops the re-recited spring/capacitor/load list (Movement B owns those via its dedicated callback panels); trims the fluid line to just what its own valve/gauge panels show; keeps the definition, the isolation-vs-removal principle, and the "six steps, not three" payoff. It reads as the crisp rule Movement B was building toward, not a second pass over the same ground.
- **Primacy stated once:** removed STORED ENERGY's "the concept that matters most in this entire course" line. Movement B's "the heart of this module" survives, since Movement B/A content was off-limits for this pass.
- **Movement A/B untouched, all 7 source_refs unchanged** — re-verified every anchor still grep-matches `courses/loto/sources/29-CFR-1910.147.md` after editing.
- **OFF ISN'T SAFE** untouched, as instructed — it's a distinct bridge, not a duplicate.

## Caught while verifying downstream consistency
The task asked me to confirm nothing downstream (quiz, end card, six-steps preview) contradicts the slimmed section. Found and fixed one leftover from the original Phase 1 refactor: **THE SIX STEPS PREVIEW** still said "they've only locked one source out of **five**" — corrected to **six**, matching the corrected taxonomy. Swept the whole file for other stray "five" references; the remaining two ("the other five can kill you" and "five-panel list" in production notes) are both correct as written (6 sources − 1 electrical = 5; production notes describing the pre-refactor structure for comparison).

## Skipped
The optional thermal Movement B callback ("that oven surface is still hot from the last shift") — brief's stated default, and I didn't find a version that read as adding real content rather than padding a de-duplication pass. Easy to add separately if you want it.

## Test plan
- [x] Primacy superlative appears exactly once (grep-verified)
- [x] Four-example recitation no longer duplicated (grep-verified)
- [x] All 7 source_refs still present and anchor-verified against the frozen file
- [x] No remaining "out of five" / stray five-source references
- [ ] Sean review

🤖 Generated with [Claude Code](https://claude.com/claude-code)