### PR TITLE
Add citation chips + Learner/Reviewer toggle to Module 1 player

### DIFF
--- a/courses/loto/builds/module-01/index.html
+++ b/courses/loto/builds/module-01/index.html
@@ -676,7 +676,7 @@ html, body {
 
 /* Text shadow for body text over dark backgrounds - enhanced */
 .slide-keypoint .body,
-.slide-reveal .body, 
+.slide-reveal .body,
 .slide-concept .body,
 .slide-scene p,
 .slide-list .item-text,
@@ -684,6 +684,46 @@ html, body {
   text-shadow: 0 2px 12px rgba(0,0,0,0.8), 0 1px 3px rgba(0,0,0,0.9);
 }
 
+/* --- Citation chip (Reviewer mode) --- */
+.citation-chip {
+  position: absolute;
+  right: 2vw;
+  bottom: 1.5vh;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  letter-spacing: 0.03em;
+  color: var(--steel-dim);
+  background: rgba(42,42,42,0.72);
+  border: 1px solid var(--steel-blue);
+  border-radius: 4px;
+  padding: 0.4em 0.7em;
+  text-decoration: none;
+  backdrop-filter: blur(3px);
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+.citation-chip:hover {
+  color: var(--safety-yellow);
+  border-color: var(--safety-yellow);
+}
+.citation-chip-icon {
+  opacity: 0.8;
+}
+
+/* --- Learner/Reviewer toggle --- */
+.bottom-bar-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.mode-toggle-btn[aria-pressed="true"] {
+  background: var(--safety-yellow);
+  color: var(--bg-dark);
+  border-color: var(--safety-yellow);
+}
 
 
 
@@ -699,7 +739,10 @@ html, body {
   <div class="slide-container" id="slideContainer"></div>
 
   <div class="bottom-bar">
-    <a href="../index.html" class="nav-btn" style="margin-right: 2vw;">MENU</a>
+    <div class="bottom-bar-left">
+      <a href="../index.html" class="nav-btn">MENU</a>
+      <button class="nav-btn mode-toggle-btn" id="modeToggleBtn" onclick="toggleReviewerMode()" aria-pressed="false" title="Toggle citation view for review/compliance">Learner Mode</button>
+    </div>
     <div class="progress-section">
       <div class="progress-track">
         <div class="progress-fill" id="progressFill"></div>
@@ -767,6 +810,32 @@ let quizAnswers = [];
 let quizMode = false;
 let currentQuizQuestion = 0;
 let isAnswered = false;
+
+// Reviewer mode: view state only, in-memory for this session. NOT persisted
+// (no localStorage) — this player gets packaged for SCORM/LMS delivery, and
+// LMS iframe storage-partitioning makes localStorage unreliable inside an SCO.
+// Never touches SCORM/LMS calls or completion/score tracking.
+let reviewerMode = false;
+
+function toggleReviewerMode() {
+  reviewerMode = !reviewerMode;
+  const btn = document.getElementById('modeToggleBtn');
+  btn.textContent = reviewerMode ? 'Reviewer Mode' : 'Learner Mode';
+  btn.setAttribute('aria-pressed', String(reviewerMode));
+  renderSlide();
+}
+
+// Returns citation chip HTML, or '' if reviewer mode is off or the source
+// is missing/incomplete. Fail-safe: never renders a partial or fabricated
+// citation — citation and url are both required.
+function renderCitation(source) {
+  if (!reviewerMode || !source || !source.citation || !source.url) return '';
+  return `
+    <a class="citation-chip" href="${source.url}" target="_blank" rel="noopener">
+      <span class="citation-chip-icon">&sect;</span>${source.citation}
+    </a>
+  `;
+}
 
 function initPlayer() {
   renderSlide();
@@ -900,9 +969,11 @@ function renderSlide() {
       `;
       break;
   }
-  
+
+  html += renderCitation(slide.source);
+
   container.innerHTML = html;
-  
+
   // Activate the slide
   setTimeout(() => {
     const slideEl = container.querySelector('.slide');
@@ -951,7 +1022,7 @@ function renderQuiz() {
     `;
   }
   
-  const html = `
+  let html = `
     <div class="slide slide-quiz active">
       <div class="quiz-container">
         <h2>Question ${currentQuizQuestion + 1}</h2>
@@ -965,7 +1036,9 @@ function renderQuiz() {
       </div>
     </div>
   `;
-  
+
+  html += renderCitation(question.source);
+
   container.innerHTML = html;
 }
 


### PR DESCRIPTION
## Summary
Phase 3 of the LOTO Pass-4 brief. Presentation layer only — `git diff` is confined to the CSS block, nav-bar HTML, and the two render functions. No slide, quiz, or `source` object touched (Phase 2's 7 verified citations are unchanged).

- **`renderCitation(source)`** — fail-safe helper: renders a chip only when `reviewerMode === true` AND `source.citation` AND `source.url` are both present. Returns `''` otherwise, so a partial/malformed source object never produces a broken or fabricated chip.
- **Single injection point** per function, as specified: `html += renderCitation(...)` after the slide-type switch in `renderSlide()`, and the same in `renderQuiz()` (changed that function's local `html` from `const` to `let` to allow the append — mirrors `renderSlide()`'s pattern exactly, per "do the same").
- **Learner/Reviewer toggle** — one button in the nav bar next to MENU, reusing `.nav-btn` styling with an `aria-pressed`-driven gold highlight as the mode indicator (same gold the existing `:hover` state already uses, so it's visually consistent, not a new color). `reviewerMode` is a plain in-memory JS variable — no `localStorage`, no SCORM/LMS calls of any kind, resets on reload as required. Toggling re-renders the current view immediately (mid-slide or mid-quiz), no re-navigation needed.

## Verification
**Static/logic (Node):** extracted the MODULE object + `renderCitation` and simulated every slide/quiz item — Learner mode produces 0 chips across all 32 slides + 4 quiz items; Reviewer mode produces exactly 7, matching Phase 2's verified source count. Confirmed fail-safe behavior against `null`, `undefined`, and partial source objects (missing `url` or `citation`) — all render `''`.

**Real browser (Playwright/Chromium — installed fresh for this check, since this is a UI change and static verification alone isn't "running the app"):** navigated all 32 slides in both modes, clicked the toggle mid-module and confirmed chips vanish without re-navigating, walked into the quiz and answered Q3. Result: chips appeared on exactly slides 8, 10, 13, 14, 18, 32, and quiz Q3 — each with the correct `href` (all six eCFR URLs), `target="_blank"`, `rel="noopener"`. **Zero console errors** across the whole run. Screenshots confirm the chip is small/muted/bottom-right and never overlaps slide content, and the toggle button matches the existing `.nav-btn` look:

| Slide 8 (concept, no image) | Slide 14 (Movement B intro) | Quiz Q3 (answered) |
|---|---|---|
| Chip: `§ 29 CFR 1910.147(b)` | Chip: `§ 29 CFR 1910.147(d)(5)(i)` | Chip: `§ 29 CFR 1910.147(b); (d)(5)(i)` |

## Guardrails honored
- [x] `git diff` shows zero changes to slide/quiz/source content
- [x] All 7 citations are byte-identical to Phase 2 (untouched, not re-derived)
- [x] SCORM-safe: no persistence, no LMS calls, pure view state
- [x] Written as a clean, reusable pattern (helper + single injection point + toggle) for Phase 4 to carry into Modules 2/3 — those players are **not** touched in this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)