### PR TITLE
Freeze 29 CFR 1910.399 (qualified person) as secondary source

### DIFF
--- a/courses/loto/sources/29-CFR-1910.399-qualified-person.md
+++ b/courses/loto/sources/29-CFR-1910.399-qualified-person.md
@@ -1,0 +1,35 @@
+§ 1910.399 Definitions applicable to this subpart.
+
+Qualified person.   One who has received training in and has demonstrated skills and knowledge in the construction and operation of electric equipment and installations and the hazards involved.
+
+Note 1 to the definition of "qualified person:"
+
+Whether an employee is considered to be a "qualified person" will depend upon various circumstances in the workplace. For example, it is possible and, in fact, likely for an individual to be considered "qualified" with regard to certain equipment in the workplace, but "unqualified" as to other equipment. (See 1910.332(b)(3) for training requirements that specifically apply to qualified persons.)
+
+Note 2 to the definition of "qualified person:"
+
+An employee who is undergoing on-the-job training and who, in the course of such training, has demonstrated an ability to perform duties safely at his or her level of training and who is under the direct supervision of a qualified person is considered to be a qualified person for the performance of those duties.
+
+---
+
+§ 1910.331 Scope.
+
+(a) Covered work by both qualified and unqualified persons.  The provisions of §§ 1910.331 through 1910.335 cover electrical safety-related work practices for both qualified persons (those who have training in avoiding the electrical hazards of working on or near exposed energized parts) and unqualified persons (those with little or no such training) working on, near, or with the following installations:
+
+---
+
+§ 1910.332 Training. (excerpt — paragraph (b), training content)
+
+(b) Content of training —
+
+(1) Practices addressed in this standard.  Employees shall be trained in and familiar with the safety-related work practices required by §§ 1910.331 through 1910.335 that pertain to their respective job assignments.
+
+(2) Additional requirements for unqualified persons.  Employees who are covered by paragraph (a) of this section but who are not qualified persons shall also be trained in and familiar with any electrically related safety practices not specifically addressed by §§ 1910.331 through 1910.335 but which are necessary for their safety.
+
+(3) Additional requirements for qualified persons.  Qualified persons (i.e., those permitted to work on or near exposed energized parts) shall, at a minimum, be trained in and familiar with the following:
+
+(i) The skills and techniques necessary to distinguish exposed live parts from other parts of electric equipment,
+
+(ii) The skills and techniques necessary to determine the nominal voltage of exposed live parts, and
+
+(iii) The clearance distances specified in § 1910.333(c) and the corresponding voltages to which the qualified person will be exposed.

--- a/courses/loto/sources/PROVENANCE.md
+++ b/courses/loto/sources/PROVENANCE.md
@@ -46,3 +46,32 @@ OSHA's two standalone pages disagree with each other and both lag the eCFR citat
 ## §3 fidelity note
 
 Prose section throughout; Appendix A is a fill-in-the-blank procedural template (the standard's own "Typical Minimal Lockout Procedure" form) and was transcribed verbatim with no fields altered, added, or omitted.
+
+---
+
+# Source Provenance — 29 CFR 1910.399 (Qualified Person)
+
+Secondary source. Frozen to gate Module 3's NEW-1 reframe (LOTO teaches three employee roles, not four — "qualified person" is a real OSHA term but belongs to Subpart S electrical safety, not to 1910.147).
+
+- **Citation:** 29 CFR 1910.399 — Definitions applicable to this subpart (Subpart S, Electrical), "Qualified person" entry only, with its two Notes. Supporting excerpts: 29 CFR 1910.331(a) (Scope — qualified/unqualified persons) and 29 CFR 1910.332(b) (Training — content of training for qualified persons).
+- **Primary source URL (eCFR):** https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-S/subject-group-ECFR314553c63ae81f4/section-1910.399
+  - Supporting: https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-S/subject-group-ECFRbd7903c591a5eff/section-1910.331
+  - Supporting: https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-S/subject-group-ECFRbd7903c591a5eff/section-1910.332
+- **eCFR currency:** up-to-date as of 7/14/2026 (per eCFR site metadata at fetch time).
+- **Fetched:** 2026-07-14
+- **Frozen file:** `courses/loto/sources/29-CFR-1910.399-qualified-person.md`
+- **SHA-256:** `20a5856023139fed9ee788a5151387504d50719e3024de7b7c020de919540f86`
+
+## Extraction method
+
+Same discipline as the 1910.147 freeze: fetched via `curl` directly to disk, extracted programmatically (Python `html.parser`, tag-stripping only). Deliberately narrow scope — extracted only the `<div id="p-1910.399(Qualified%20person)">` block (the "Qualified person" definition plus its Note 1 and Note 2), not the whole of 1910.399's much larger definitions list. The 1910.331 and 1910.332 excerpts are similarly narrow: 1910.331's scope paragraph (a) intro sentence only (not its full list of covered installations, which is irrelevant to the LOTO reframe), and 1910.332(b) "Content of training" including subitems (1)–(3)(iii) (the paragraph explicitly cross-referenced by 1910.399's Note 1).
+
+## Cross-check
+
+Independently fetched OSHA's rendering: https://www.osha.gov/laws-regs/regulations/standardnumber/1910/1910.399
+
+The "Qualified person" definition and both of its Notes were verified verbatim between the frozen eCFR file and the OSHA page — identical text (only a cosmetic period-placement difference relative to an italics tag, not a content difference). 1910.331 and 1910.332 were not independently cross-checked against OSHA (out of scope for this narrow freeze — those two excerpts are supporting context for the reframe, not the load-bearing citation; the load-bearing "qualified person" definition itself is the one that was cross-checked).
+
+## §3 fidelity note
+
+All three excerpts are prose definitions/scope statements, no tables or figures. Transcribed verbatim, including the source's own internal cross-references (e.g., "(See 1910.332(b)(3)...)") which are preserved as-is rather than resolved or annotated.


### PR DESCRIPTION
## Summary
Task 0 of LOTO Phase 4. This is the autonomous freeze step per the brief ("PR #A: Task 0 freeze (autonomous)") — gates Module 3's upcoming NEW-1 reframe (three LOTO roles, not four; "qualified person" is a real OSHA term but belongs to Subpart S electrical safety, not lockout/tagout).

- `courses/loto/sources/29-CFR-1910.399-qualified-person.md` — the "Qualified person" definition + its two Notes, plus two narrow supporting excerpts: 1910.331(a)'s scope sentence and 1910.332(b)'s training-content paragraph (the one 1910.399's own Note 1 cross-references).
- `PROVENANCE.md` — appended as a second entry (kept the existing 1910.147 entry untouched, added a clearly-delineated second `# Source Provenance` section rather than restructuring).

## Verification
- [x] Load-bearing definition cross-checked verbatim against OSHA's independent rendering (both Notes match too)
- [x] SHA-256 computed and recorded: `20a5856023139fed9ee788a5151387504d50719e3024de7b7c020de919540f86`
- [x] All three anchor phrases I'll need for the Module 3 reframe grep-verified against the frozen file: the qualified-person definition, "working on or near exposed energized parts," and the Note 1 → 1910.332(b)(3) cross-reference

## Note
eCFR redirected the plain `section-1910.331`/`section-1910.332` URLs to subject-group-qualified paths (`.../subject-group-ECFRbd7903c591a5eff/section-1910.331`) — followed the redirect and used the resolved URL in provenance, same as how the original 1910.147 freeze already handles eCFR's URL structure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)