### PR TITLE
Modules 2 & 3: audit fixes (B3, F1, F2, F3, F4, F6) + M3 three-role r…

### DIFF
--- a/courses/loto/DECISIONS-NEEDED.md
+++ b/courses/loto/DECISIONS-NEEDED.md
@@ -1,0 +1,32 @@
+# Decisions Needed — LOTO Course
+
+Decisions surfaced during Pass-4 rework that require the accountable signer's call, per Durability Standard §2.4 (referenced-source dispositions) and §5 (conflict log / decision records). Not resolved here — logged for Sean to decide.
+
+---
+
+## 1. Scope exclusions — accept, exclude with rationale, or fold in?
+
+Three provisions of 29 CFR 1910.147 are within scope of the standard but currently unaddressed by the course. `AUDIT-2026-07-11.md`'s SCOPE NOTES flagged these as candidates for a recorded scope decision, not defects — the course teaches the cautious default in each case, it just doesn't teach the exception.
+
+- **Cord-and-plug exclusion — 1910.147(a)(2)(iii)(A).** The standard exempts work on cord-and-plug-connected electric equipment where exposure is controlled by unplugging the equipment and the plug is under the exclusive control of the employee doing the work. Daily reality in small shops; the course currently teaches full LOTO for everything.
+- **Minor-servicing exception — 1910.147(a)(2)(ii) Note.** The standard's minor tool-change/adjustment exception (routine, repetitive, integral to production, using alternative measures providing effective protection). Unaddressed; course teaches the cautious default.
+- **Testing/positioning re-energization — 1910.147(f)(1).** The standard's specific sequence for temporarily re-energizing equipment to test or position it during service. Unaddressed.
+
+**Decision needed:** For each of the three — record as a deliberate scope exclusion (with rationale, on the record per §2.4), or fold it into the course as new content? If excluded, does the accountable-signer sign-off happen now or wait for a client engagement where it matters?
+
+---
+
+## 2. Interpretation letters as secondary sources — freeze, or stay regulation-only?
+
+Two places in the course rely on reasoning that goes slightly beyond the plain text of 29 CFR 1910.147 and its Appendix A:
+
+- **Thermal energy / ovens.** Module 1's thermal-energy panel (Phase 1 fix, B1) is grounded in 1910.147(b)'s definition, which does name "thermal" as an energy source — that part is solid and already frozen. The audit's original note additionally flagged an OSHA interpretation letter (2000-04-11, Dykes) that treats a natural-gas oven as an energy source on thermal-hazard grounds — this letter was **not** used as a source for the shipped fix, but it's available if Sean wants added support for the thermal reframe.
+- **Master keys.** Module 2's master-key material was reframed (Phase 4, F3) from a claimed regulatory prohibition to a program-design principle flowing from exclusive control — the frozen text contains no master-key prohibition, so the fix doesn't cite one. If there's an interpretation letter or other secondary source that speaks to master keys and exclusive control more directly, it could strengthen that section, but none has been frozen or used.
+
+**Decision needed:** Freeze either or both of these as secondary sources (same discipline as the 1910.399 freeze — §2.1/§2.2, accepted and frozen before use), or keep the course scoped to the regulation text, Appendix A, and 1910.399 only? Interpretation letters are not self-executing law the way the regulation is; treating one as a source is itself a scope decision, not a mechanical freeze.
+
+---
+
+## Status
+
+Both items are open. Neither blocks the Phase 4 script fixes or build regeneration — none of the shipped fixes depend on resolving these. Route through the conflict-log / decision-record process (Durability Standard §5) when Sean is ready to rule on them.

--- a/courses/loto/scripts/module-02-the-six-steps.md
+++ b/courses/loto/scripts/module-02-the-six-steps.md
@@ -145,14 +145,14 @@ Each worker applies their own lock. Each lock has one key. No master keys. No sh
 
 *[Beat.]*
 
-If three people are working on the same machine, three locks go on the isolation point. The machine cannot be re-energized until all three people have removed their own lock. No one removes someone else's lock. Ever.
+If three people are working on the same machine, three locks go on the isolation point. The machine cannot be re-energized until all three people have removed their own lock. No one removes someone else's lock. Ever — except through one narrow, employer-directed emergency procedure we'll cover in Module 3. That's not a coworker deciding to take your lock off. It's a documented process with its own steps, and it's the only exception to this rule.
 
 **NARRATOR (V.O.):**
 Think about what this means. Your lock is your personal guarantee that the machine will not start while your hands are inside it. Not your supervisor's guarantee. Not the company's guarantee. Yours. You put it on. You take it off. Only when you are done and clear.
 
 *[Beat.]*
 
-This is why master keys are prohibited. A master key means someone else can override your decision that this machine isn't safe to start yet. A master key means your protection depends on someone else's judgment about whether you're done.
+This is why a well-run lockout program doesn't use master keys. Not because a regulation uses that phrase — it doesn't. It's a design principle that follows directly from exclusive control: your lock, your key, your guarantee. A master key breaks that chain. It means someone else can override your decision that this machine isn't safe to start yet, and your protection ends up depending on someone else's judgment about whether you're done.
 
 Your life, someone else's judgment. That's not a system. That's a gamble.
 
@@ -174,7 +174,11 @@ A tag is not a barrier. You cannot physically prevent a machine from starting wi
 
 *[Beat.]*
 
-OSHA's standard is clear: lockout is the default. Tagout alone is only acceptable when the machine physically cannot accommodate a lock — and even then, the employer must prove that the tagout program provides equivalent protection. Tags supplement locks. They don't replace them.
+Here's how the standard actually structures it, and it's two different cases, not one. If an energy isolating device physically cannot accommodate a lock, tagout is required — that's the whole requirement for that case. But if a device *can* be locked out and the employer chooses tagout instead, that's a different situation with a different bar: the employer has to demonstrate that the tagout program provides a level of protection equivalent to lockout.
+
+<!-- source_ref: { citation: "29 CFR 1910.147(c)(2)(i), (c)(2)(ii)", url: "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(c)(2)(i)", anchor: "(c)(2)(i): \"If an energy isolating device is not capable of being locked out, the employer's energy control program under paragraph (c)(1) of this section shall utilize a tagout system.\" / (c)(2)(ii): \"If an energy isolating device is capable of being locked out, the employer's energy control program under paragraph (c)(1) of this section shall utilize lockout, unless the employer can demonstrate that the utilization of a tagout system will provide full employee protection as set forth in paragraph (c)(3) of this section.\" -- two separate numbered paragraphs in the frozen file, quoted separately here, not a continuous span." } -->
+
+Two different cases, two different rules. Either way: tags supplement locks. They don't replace them by default.
 
 The cold open showed you what a request looks like: a sign on a breaker panel. Someone walked right past it. A tag without a lock is the same vulnerability with a fancier label.
 
@@ -208,6 +212,15 @@ Capacitors are still charged. Discharge them per the manufacturer's procedure.
 
 **NARRATOR (V.O.):**
 Each of these is specific to the machine and the energy type. This is why your machine-specific procedure lists stored energy hazards and how to address each one. Generic procedures can't tell you where the bleed valve is on your hydraulic press. Only the procedure for your specific machine can do that.
+
+*[Beat.]*
+
+**NARRATOR (V.O.):**
+One more thing about this step, and it's easy to miss: relieving stored energy once isn't always the end of it. Some systems build energy back. A pneumatic line can re-pressurize. A capacitor bank can recharge. Hydraulic pressure can creep back up over time, even after you've bled it down.
+
+<!-- source_ref: { citation: "29 CFR 1910.147(d)(5)(ii)", url: "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(d)(5)(ii)", anchor: "If there is a possibility of reaccumulation of stored energy to a hazardous level, verification of isolation shall be continued until the servicing or maintenance is completed, or until the possibility of such accumulation no longer exists." } -->
+
+If your machine can do that — if there's a real possibility that stored energy reaccumulates to a hazardous level — checking once at the start isn't enough. Verification continues for as long as the job takes, or until there's no way for that energy to come back. Step five isn't always a one-time box to check. Sometimes it's a box you keep checking.
 
 ---
 
@@ -327,7 +340,7 @@ Everyone goes home safe.
 - Step 2 (Shutdown): Use normal stopping procedures, verify all movement has stopped
 - Step 3 (Isolate): Disconnect from every energy source — not just electrical
 - Step 4 (Lock): One person, one lock, no master keys — your lock is your personal guarantee
-- Step 5 (Stored energy): Address what's left — bleed, block, discharge, release
+- Step 5 (Stored energy): Address what's left — bleed, block, discharge, release. Where energy can build back, verification continues until the job is done
 - Step 6 (Verify): Try to start the machine — silence is proof
 - Tags supplement locks but never replace them
 - The simplicity of the procedure is what makes skipping it so tempting — and so dangerous

--- a/courses/loto/scripts/module-03-when-simple-gets-complicated.md
+++ b/courses/loto/scripts/module-03-when-simple-gets-complicated.md
@@ -158,9 +158,11 @@ The temptation is obvious: cut the lock. Start the machine. Deal with the paperw
 *[Beat.]*
 
 **NARRATOR (V.O.):**
-The procedure is specific and it exists to prevent exactly the disaster you're imagining.
+The procedure is specific and it exists to prevent exactly the disaster you're imagining. And it's important to say what this is *not*: it's not a coworker's judgment call. This only happens under the direction of the employer, through a specific procedure that's been developed, documented, and built into the energy control program *before* anyone needs it. Nobody improvises this in the moment.
 
-First: verify that the authorized employee who applied the lock is not in the facility. Not in the building. Not in a different area. Not on break. Verified absent.
+<!-- source_ref: { citation: "29 CFR 1910.147(e)(3)", url: "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(e)(3)", anchor: "Exception to paragraph (e)(3): When the authorized employee who applied the lockout or tagout device is not available to remove it, that device may be removed under the direction of the employer, provided that specific procedures and training for such removal have been developed, documented and incorporated into the employer's energy control program." } -->
+
+That documented procedure has three elements. First: verify that the authorized employee who applied the lock is not in the facility. Not in the building. Not in a different area. Not on break. Verified absent.
 
 Second: make reasonable efforts to contact them. Call them. If you can't reach them, document the attempts.
 
@@ -190,20 +192,35 @@ That's why the notification requirement exists. The lock removal isn't complete 
 **NARRATOR (V.O.):**
 One more piece. The roles.
 
-The OSHA standard defines four types of employees in a lockout/tagout program. This matters because each role carries different responsibilities, different training requirements, and different obligations.
+This standard defines three roles in a lockout/tagout program. This matters because each role carries different responsibilities, different training requirements, and different obligations.
 
-*[VISUAL: Four roles — Authorized, Affected, Qualified, Other — arranged not as a hierarchy but as concentric circles around the equipment. Authorized closest. Other furthest.]*
+<!-- source_ref: { citation: "29 CFR 1910.147(b)", url: "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(b)", anchor: "Affected employee.   An employee whose job requires him/her to operate or use a machine or equipment on which servicing or maintenance is being performed under lockout or tagout, or whose job requires him/her to work in an area in which such servicing or maintenance is being performed. / Authorized employee.   A person who locks out or tags out machines or equipment in order to perform servicing or maintenance on that machine or equipment." } -->
 
-<!-- Panel-logic reasoning: Single VISUAL, diagram style. Not a panel sequence. The concentric arrangement teaches the relationship between roles and the equipment better than a list would. McCloud would call this a non-temporal image — it shows a structure, not a narrative. The spatial relationship IS the information. -->
+*[VISUAL: Three roles — Authorized, Affected, Other — arranged not as a hierarchy but as concentric circles around the equipment. Authorized closest. Other furthest.]*
+
+<!-- Panel-logic reasoning: Single VISUAL, diagram style. Not a panel sequence. The concentric arrangement teaches the relationship between roles and the equipment better than a list would. McCloud would call this a non-temporal image — it shows a structure, not a narrative. The spatial relationship IS the information. Three rings now, not four: this needs to be regenerated, not relabeled — the fourth ring wasn't just mislabeled, it didn't belong there. Flag NEW in the image manifest. -->
 
 **NARRATOR (V.O.):**
 **Authorized employees** perform the lockout. They're trained on every energy source, every isolation point, every procedure for the machines they service. They apply the locks. They do the work. They verify the isolation.
 
 **Affected employees** don't perform lockout, but their work is affected by it. An operator whose production line is shut down for maintenance is an affected employee. Their responsibility is clear: never attempt to restart or re-energize a machine that's locked out. Ever. For any reason.
 
-**Qualified employees** work on or near exposed energized parts. They have specialized training in electrical procedures, voltage identification, and clearance distances. They may work alongside authorized employees during lockout.
-
 **Other employees** work in areas where lockout might occur. They receive basic awareness training: lockout exists, locked-out equipment is off-limits, attempting to start a locked machine can kill the person working on it.
+
+<!-- source_ref: { citation: "29 CFR 1910.147(c)(7)(i)(A), (B), (C)", url: "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(c)(7)(i)(A)", anchor: "(A) Each authorized employee shall receive training in the recognition of applicable hazardous energy sources, the type and magnitude of the energy available in the workplace, and the methods and means necessary for energy isolation and control. / (B) Each affected employee shall be instructed in the purpose and use of the energy control procedure. / (C) All other employees whose work operations are or may be in an area where energy control procedures may be utilized, shall be instructed about the procedure, and about the prohibition relating to attempts to restart or reenergize machines or equipment which are locked out or tagged out." } -->
+
+*[Beat.]*
+
+**NARRATOR (V.O.):**
+That's three roles, not four. You may also hear the term "qualified person" used around electrical work, and it's worth being precise about what that actually is — because it's a real OSHA term. It just doesn't live in this standard.
+
+*[Beat.]*
+
+"Qualified person" is defined in the electrical safety standards — 29 CFR 1910.399, in Subpart S — not in 1910.147. It means someone trained to work on or near exposed energized electrical parts: someone who's demonstrated the skills and knowledge to do that specific, higher-risk work safely.
+
+<!-- source_ref: { citation: "29 CFR 1910.399, \"Qualified person\"", url: "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-S/subject-group-ECFR314553c63ae81f4/section-1910.399", anchor: "Qualified person.   One who has received training in and has demonstrated skills and knowledge in the construction and operation of electric equipment and installations and the hazards involved." } -->
+
+A qualified person might also be an authorized employee on a given lockout — those aren't mutually exclusive. But "qualified person" isn't a fourth lockout/tagout role. It's a different standard answering a different question: not "what's your job on this lockout," but "are you trained to work near live electrical parts at all."
 
 *[Beat.]*
 
@@ -236,7 +253,9 @@ The training certification is the proof that you were taught this before anyone 
 
 The inspection certification is the evidence that someone watched the procedure being performed correctly and verified it.
 
-The contractor certification is the guarantee that outside personnel know your procedures and you know theirs.
+And when outside contractors are on site, there's an information exchange, not a certificate — the standard requires the on-site employer and the outside employer to inform each other of their respective lockout/tagout procedures. It's not a document either side signs and files. It's a conversation that has to happen before contractors touch your equipment, so no one is guessing at a procedure they've never seen.
+
+<!-- source_ref: { citation: "29 CFR 1910.147(f)(2)(i)", url: "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(f)(2)(i)", anchor: "Whenever outside servicing personnel are to be engaged in activities covered by the scope and application of this standard, the on-site employer and the outside employer shall inform each other of their respective lockout or tagout procedures." } -->
 
 *[Beat.]*
 
@@ -294,10 +313,12 @@ Everyone goes home safe.
 - Restoring equipment has its own seven-step sequence — check for personnel before removing any locks
 - Group lockout: one person, one lock still applies — the lockbox method scales the principle
 - Shift changes: new lock ON before old lock OFF — the overlap eliminates the gap
-- Emergency lock removal: verify absence, attempt contact, notify before return
-- Four roles: Authorized, Affected, Qualified, Other — each with specific responsibilities
+- Emergency lock removal: verify absence, attempt contact, notify before return — and only ever under the employer's documented procedure
+- Three roles: Authorized, Affected, Other — each with specific responsibilities. "Qualified person" is a real OSHA term, but it's an electrical-safety term (1910.399), not a fourth LOTO role
 - The paperwork is evidence that the system worked and everyone goes home safe
 - Annual inspections: the system checking itself
+
+**The course, in one line:** Six named energy sources, each with its own stored-energy shadow. Six steps that turn "off" into "safe." Three roles, each with a job. And a set of protocols — group lockout, shift overlap, emergency removal, outside contractors — for when the simple case gets complicated.
 
 **Course Complete.**
 *Lockout/Tagout — Control of Hazardous Energy*
@@ -338,10 +359,11 @@ A machine has room for only one lock on its energy isolation point, but four wor
 An operator's production line is shut down because maintenance is performing lockout/tagout on a connected machine. The operator is classified as:
 - A) An authorized employee, because they operate the equipment
 - B) An affected employee, whose primary responsibility is to never attempt to restart locked-out equipment
-- C) A qualified employee, because they understand how the machine works
+- C) A qualified person, since this standard uses that term for anyone experienced with the equipment
 - D) An other employee, because they aren't involved in the maintenance
 
 **Correct Answer: B**
+*(Distractor note for the build pass: C is wrong on two counts, and the quiz feedback should say so — this standard doesn't define "qualified person" at all, and where the term IS defined (1910.399), it means trained to work on or near exposed energized electrical parts, not "experienced with the equipment." This option exists to test the reframe taught in WHO DOES WHAT, not just to be a plausible-sounding wrong answer.)*
 
 ---
 


### PR DESCRIPTION
…eframe

Tasks 1-3 of LOTO Phase 4. Every correction written from the frozen sources (29-CFR-1910.147.md, plus the new 29-CFR-1910.399-qualified- person.md), source_ref on every claim, all 7 grep-verified.

Module 2 (courses/loto/scripts/module-02-the-six-steps.md):
- B3 (blocker): Step Five omitted (d)(5)(ii) entirely. Added the reaccumulation caveat to the narration (pneumatics re-pressurize, capacitors recharge, hydraulic pressure creeps) plus an end-card line.
- F1: Tagout structure was garbled — the script attached the full-protection demonstration to the wrong case. Restated accurately as two separate cases per (c)(2)(i)/(c)(2)(ii): non-lockable devices just need tagout; lockable devices where the employer chooses tagout anyway need the equivalent-protection demonstration.
- F2: "No one removes someone else's lock. Ever." now points forward to the M3 employer-directed emergency exception, so M2 and M3 don't contradict each other.
- F3: "Master keys are prohibited" reframed from a claimed regulatory fact (the frozen text contains no such prohibition) to a program-design principle flowing from exclusive control.

Module 3 (courses/loto/scripts/module-03-when-simple-gets-complicated.md):
- F4: Emergency lock removal now states its container — this only happens under the employer's direction, per a procedure developed, documented, and incorporated into the energy control program in advance, per (e)(3).
- F6: "Contractor certification" reframed as what (f)(2)(i) actually requires — a mutual information exchange between on-site and outside employers, not a certification artifact.
- NEW-1 (the reframe): WHO DOES WHAT now teaches three roles — authorized, affected, other — matching what 1910.147(b) and (c)(7)(i) actually define. Added a cross-standard reframe beat: "qualified person" is a real OSHA term, but it's a Subpart S electrical-safety term (1910.399) meaning someone trained to work on or near exposed energized parts — not a fourth LOTO role. Anchored to the newly-frozen 29-CFR-1910.399-qualified-person.md (PR #65). Concentric-circles VISUAL goes four -> three (flagged NEW for the image manifest). End card and Quiz Q4 updated to match — Q4's "qualified person" distractor is now retuned to test the exact misconception the section corrects, not just be generically wrong.
- NEW-2: Added a course-level recap line to the end card (six sources / six steps / three roles / complex-situation protocols) so Phase 4's build regen has correct content to build the "course complete" slide from.

Task 3 — cross-module consistency sweep (scripts + builds, all three modules): zero hits for "five type(s)"/five-energy taxonomy language and four-role/four-employee framing in any script or build going forward, except one confirmed, expected finding: module-03.json and module-03/index.html's existing BUILD still fabricates a "Five types of hazardous energy" course-complete slide that was never in any script — exactly the NEW-2 finding this brief described. Left untouched here by design; Phase 4 (build regen, not this PR) replaces it by building from the corrected script instead of hand-patching the drifted build. "master key" hits are all in this PR's own corrected M2 text (practice description + explicit principle-not-regulation framing) — "prohibited" itself no longer appears anywhere in any script.

Task 5 — courses/loto/DECISIONS-NEEDED.md created (did not exist before): logs the two open decisions from the brief (scope exclusions for cord-and-plug/minor-servicing/testing-positioning; whether to freeze interpretation letters for master-keys/thermal support) without resolving either.

Base: this branch stacks on the unmerged 1910.399 freeze (PR #65) since the M3 reframe's source_ref needs that frozen file to exist.

Per the brief: PAUSE here for review. Phase 4 (build regeneration) does not start until these scripts are reviewed.