### PR TITLE
Regenerate M2/M3 builds from final scripts + citation toggle

### DIFF
--- a/courses/loto/builds/module-02-image-manifest.md
+++ b/courses/loto/builds/module-02-image-manifest.md
@@ -1,0 +1,51 @@
+# Module 2 — Slide → Image Manifest
+
+Built against the regenerated `module-02.json` (23 slides), Phase 4b of the LOTO Pass-4 rework. Every candidate below was opened and visually checked against the new slide content — not filename-matched. Do not trust slide numbering carried over from the old build; both the script and the decomposition changed.
+
+## Reused (7 images — visually verified)
+
+| Slide | Content | Image | Note |
+|---|---|---|---|
+| 5 | Step One — Prepare | `s05-prepare.jpg` | Worker reading a "Lock-Out Tagout" clipboard checklist, tools nearby. Clean, legible, no wrong claims. |
+| 7 | Step Two — Shutdown | `s06-shutdown.jpg` | Gloved hand pressing a red stop button near conveyor rollers. Clean match. |
+| 8 | Step Three — Isolate | `s07-isolate.jpg` | Three-panel composite: electrical disconnect (OFF), a valve, a hose fitting. Matches the script's own three-panel isolation sequence closely. |
+| 9 | Step Four — Lock | `s08-lockout.jpg` | Hand applying a padlock + tag to a disconnect. **Caveat:** tag has partial text ("OUT," likely cropped "LOCKOUT") baked in — not a wrong claim, just a minor style-rule violation (no-text-in-image). Usable but worth a clean regenerate if budget allows. |
+| 13 | Tags vs. Locks | `s12-tags-vs-locks.jpg` | Two-panel composite: solid padlock / lock+tag with a blank (no legible text) tag. Clean. |
+| 15 | Step Five — Stored Energy | `s09-stored-energy.jpg` | Hand bleeding a hydraulic line into a catch pan, gauge visible with no misleading number baked in. Clean. |
+| 17 | Step Six — Verify | `s10-verify.jpg` | Hand pressing an E-stop-style button. Reasonable match, not a perfect literal "start button" but close enough thematically. |
+
+## Rejected — do not reuse
+
+| Old file | Problem |
+|---|---|
+| `s01-handwritten-sign.jpg` | The sign shows **garbled, illegible handwriting** ("Way what... I do cant... bar/wg wk") — nonsensical AI-generated text, not the script's "DO NOT TURN ON — Mike working on Line 3." Violates the no-text-in-image rule *and* is illegible/wrong. |
+| `s11-one-person-one-lock.jpg` | Three padlocks on a hasp labeled **"FULD DLOWK"** — garbled text (evidently meant to read something else). Same class of defect as Module 1's Phase 2 findings. |
+| `s15-six-steps-complete.jpg` | Tag reads **"LOCKLLOW / TAG OUT"** — garbled ("LOCKOUT" misspelled). Otherwise a strong composition (press with load blocked, padlock+tag, gauge at zero); worth regenerating clean rather than discarding the concept. |
+| `s02-flips-breaker.jpg` | Illegible scribbled sign (not a wrong-fact problem, just decorative), and the breaker's ON/OFF state in the image doesn't clearly match "flips the breaker to ON." Weak match, not confidently reusable. |
+| `s03-sign-vs-lock.jpg` | Two-panel composite built for the old script's structure (illegible note + bare padlock). Doesn't cleanly map to any single new slide. |
+| `s04-six-steps.jpg` | Footprints on a factory floor — atmospheric, but doesn't convey "six steps as layers," which is what the "Why Order Matters" slide needs. |
+
+## Not individually viewed this pass
+
+`s13-experienced-worker.jpg`, `s14-just-this-once.jpg` — tied to the old script's "psychology of skipping" framing, which is now a different structure (a 5-item excuse list vs. two named beats). Low priority; default to NEW rather than assumed-reusable until checked.
+
+## NEW — needs generation (6 slides)
+
+| Slide | Content | Why new |
+|---|---|---|
+| 2 | Cold open — sign on breaker, hand flips it ON | `s01`/`s02` both rejected/weak (garbled or ambiguous text) |
+| 3 | Reveal — "A sign is not a lock" | `s03` was built as a different two-panel structure; no clean single-image match |
+| 4 | Keypoint — "Why Order Matters" (six steps as layers) | `s04`'s footprints don't convey the concept |
+| 10 | Concept — "One Person, One Lock" | `s11` rejected (garbled "FULD DLOWK" text) |
+| 21 | Scene — callback, breaker panel with lock replacing sign | No existing equivalent verified; old ending diverged from new callback structure |
+| 22 | Scene — callback, inside the machine, steady work | Same reasoning |
+
+## No image needed by design (10 slides)
+
+Typography-forward per the script's own tone notes, or conventionally image-less types (title, list, summary): slides 1 (title), 6 (notify — also step one), 11 (why no master keys — typography-forward reveal), 14 (tags actual structure — regulatory-quote slide, matches M1's convention of citation slides going image-less), 16 (reaccumulation — same), 18 (psychology excuses list), 19 (psychology truth reveal), 20 (psychology whole-point keypoint), 23 (closing reveal — could take `s15` if regenerated clean, otherwise stays typography-forward), 24 (summary).
+
+## Priority for the next image-generation pass
+
+1. **Cold open (slide 2)** — first thing a learner sees; currently has no clean asset.
+2. **One Person, One Lock (slide 10)** and **the two callback slides (21, 22)** — load-bearing narrative beats with no reusable art.
+3. Regenerate `s08-lockout.jpg` and `s15-six-steps-complete.jpg` clean (fix the baked-in text) rather than starting from scratch — both have strong compositions already.

--- a/courses/loto/builds/module-02.json
+++ b/courses/loto/builds/module-02.json
@@ -1,100 +1,83 @@
 {
-  "title": "The Six Steps", 
+  "title": "The Six Steps",
   "moduleNumber": 2,
   "partLabel": "Part Two — The Procedure That Keeps You Alive",
   "passingScore": 75,
 
   "slides": [
     { "type": "title", "moduleLabel": "Module 2", "heading": "The Six Steps", "subtitle": "Part Two — The Procedure That Keeps You Alive", "brand": "SOPs Nobody Reads" },
-    
-    { "type": "scene", "label": "Cold Open", "text": "A breaker panel in a hallway. Someone has taped a handwritten sign next to one of the breakers: <em>\"DO NOT TURN ON — Mike working on Line 3.\"</em> The tape is peeling at one corner.", "image": "img/s01-handwritten-sign.jpg" },
-    
-    { "type": "scene", "label": "Scene", "text": "A hand reaches past the sign and flips the breaker to ON. The sign flutters. The hand belongs to someone who didn't read it, or didn't think it applied to them.", "image": "img/s02-flips-breaker.jpg" },
-    
-    { "type": "reveal", "kicker": "The Difference", "heading": "A sign is not a lock.\nA sign is a request.\nA lock is a fact.", "body": "And the difference between a request and a fact is the distance between going home tonight and not.", "image": "img/s03-sign-vs-lock.jpg" },
-    
-    { "type": "keypoint", "kicker": "Why Order Matters", "heading": "Six steps.\nSix layers of protection.", "body": "Each step handles something the previous step couldn't. Skip a layer and there's a gap. A gap in this process is a gap in your protection.", "image": "img/s04-six-steps.jpg" },
-    
-    { "type": "keypoint", "kicker": "Step 1", "heading": "Prepare for Shutdown", "body": "Find the machine-specific lockout procedure. Know what you're dealing with. Notify affected employees. This isn't paperwork — it's your map. Without it, you're guessing.", "image": "img/s05-prepare.jpg" },
-    
-    { "type": "keypoint", "kicker": "Step 2", "heading": "Equipment Shutdown", "body": "Use normal stopping procedures. Verify all moving parts have actually stopped — not almost stopped, not slowing down. Stopped. Flywheels coast. Wait for zero.", "image": "img/s06-shutdown.jpg" },
-    
-    { "type": "keypoint", "kicker": "Step 3", "heading": "Energy Isolation", "body": "Disconnect from every energy source. Electric, pneumatic, hydraulic, mechanical. Turn breakers to OFF. Close valves. Disconnect supply lines. Isolation means no energy can reach the equipment.", "image": "img/s07-isolate.jpg" },
-    
-    { "type": "keypoint", "kicker": "Step 4", "heading": "Apply Lockout Devices", "body": "Lock every isolation point. One lock per person working on the equipment. Your lock, your key, your life. Remove only your own locks when your work is complete.", "image": "img/s08-lockout.jpg" },
-    
-    { "type": "keypoint", "kicker": "Step 5", "heading": "Stored Energy Control", "body": "Relieve, disconnect, or restrain stored energy. Bleed air pressure. Discharge capacitors. Support suspended components. Release spring tension safely. Stored energy is patient — it waits.", "image": "img/s09-stored-energy.jpg" },
-    
-    { "type": "keypoint", "kicker": "Step 6", "heading": "Verify Isolation", "body": "Test that the equipment cannot be operated. Try to start it using normal procedures. Check for movement, lights, sounds. Verify zero energy state before beginning work.", "image": "img/s10-verify.jpg" },
-    
-    { "type": "concept", "label": "One Person, One Lock", "boxText": "Each worker applies their own lock and removes only their own lock.", "body": "Your lock protects you. Someone else's lock protects them. You never remove another person's lock. They never remove yours. This isn't bureaucracy — it's survival.", "image": "img/s11-one-person-one-lock.jpg" },
-    
-    { "type": "concept", "label": "Tags vs. Locks", "boxText": "Tags inform. Locks prevent. Tags supplement locks — they never replace them.", "body": "A tag tells you who's working and why. But a tag won't stop someone from flipping a switch. Use both: lock to prevent, tag to inform.", "image": "img/s12-tags-vs-locks.jpg" },
-    
-    { "type": "keypoint", "kicker": "Why People Skip Steps", "heading": "\"I've done this job\na hundred times.\"", "body": "Experience creates shortcuts. Familiarity breeds assumption. The worker who skips LOTO is usually the experienced one — the one who knows the machine, knows the work, knows it'll only take five minutes.", "image": "img/s13-experienced-worker.jpg" },
-    
-    { "type": "reveal", "kicker": "The Psychology", "heading": "Every accident starts\nwith \"just this once.\"", "body": "Just this once I'll skip the lockout. Just this once I'll reach inside while it's running. Just this once I won't wait for the moving parts to stop. Experience makes you confident. Confidence makes you careless.", "image": "img/s14-just-this-once.jpg" },
-    
-    { "type": "list", "label": "The Six Steps", "heading": "Every time. In order.", "items": [
-      { "num": "1.", "text": "<strong>Prepare:</strong> Review procedure, notify affected employees" },
-      { "num": "2.", "text": "<strong>Shutdown:</strong> Use normal stopping procedures, verify zero motion" },
-      { "num": "3.", "text": "<strong>Isolate:</strong> Disconnect from all energy sources" },
-      { "num": "4.", "text": "<strong>Lock:</strong> Apply lockout devices, one per person" },
-      { "num": "5.", "text": "<strong>Stored Energy:</strong> Relieve, disconnect, or restrain" },
-      { "num": "6.", "text": "<strong>Verify:</strong> Test that equipment cannot operate" }
-    ], "image": "img/s15-six-steps-complete.jpg" },
-    
-    { "type": "summary", "heading": "Module 2 — Key Concepts", "items": [
-      "A lock is a fact, a sign is a request",
-      "Six steps create six layers of protection",
-      "One person, one lock — your lock protects your life", 
-      "Tags inform, locks prevent — use both",
-      "Experience creates dangerous shortcuts",
-      "Every accident starts with 'just this once'",
-      "Everyone goes home safe"
-    ] }
+
+    { "type": "scene", "label": "Cold Open", "text": "A breaker panel in a hallway. A handwritten sign: \"DO NOT TURN ON — Mike working on Line 3.\" A hand reaches past it and flips the breaker to ON." },
+
+    { "type": "reveal", "kicker": "The Difference", "heading": "A sign is not\na lock.", "body": "A sign is a request. A lock is a fact. And the difference between a request and a fact is the distance between going home tonight and not." },
+
+    { "type": "keypoint", "kicker": "Why Order Matters", "heading": "Six steps.\nEach one closes\na different gap.", "body": "Each step handles something the previous step couldn't. Skip a layer and there's a gap. A gap in this process is a gap in your protection." },
+
+    { "type": "concept", "label": "Step One — Prepare", "boxText": "Find the machine-specific lockout procedure — every energy source, where it enters, what device isolates it.", "body": "This is the step most people skip. It feels like paperwork. But this form is the map. Guessing gets people hurt.", "image": "img/s05-prepare.jpg" },
+
+    { "type": "keypoint", "kicker": "Also Step One", "heading": "Notify everyone\naffected.", "body": "What's being locked out. Why. How long. Who's responsible. An affected employee who doesn't know about the lockout might try to start the machine." },
+
+    { "type": "keypoint", "kicker": "Step Two — Shutdown", "heading": "Wait for zero.\nNot \"almost stopped.\"", "body": "Flywheels coast. Gears have momentum. Use the normal stopping procedure — the one documented, the one you were trained on. Don't improvise.", "image": "img/s06-shutdown.jpg" },
+
+    { "type": "concept", "label": "Step Three — Isolate", "boxText": "Disconnect from every energy source. Not just electrical.", "body": "Electrical: disconnect to OFF, verify breaker connections open. Hydraulic/pneumatic: valves CLOSED. Chemical: valves closed, lines bled or capped. The word is isolate, not reduce.", "image": "img/s07-isolate.jpg" },
+
+    { "type": "keypoint", "kicker": "Step Four — Lock", "heading": "The physical barrier.\nOnly you have the key.", "body": "Once this lock is on, the disconnect cannot move to ON. Not by accident. Not by anyone, for any reason, unless they have the key.", "image": "img/s08-lockout.jpg" },
+
+    { "type": "concept", "label": "One Person, One Lock", "boxText": "Each worker applies their own lock. Each lock has one key.", "body": "If three people are working on the machine, three locks go on. No one removes someone else's lock — ever, except through one narrow, employer-directed emergency procedure (Module 3)." },
+
+    { "type": "reveal", "kicker": "Why No Master Keys", "heading": "Your lock.\nYour key.\nYour guarantee.", "body": "Not a regulation's phrase — a design principle. A master key means someone else can override your decision that the machine isn't safe yet. Your life, someone else's judgment. That's not a system. That's a gamble." },
+
+    { "type": "concept", "label": "Tags vs. Locks", "boxText": "A tag is a communication device. A lock is a physical barrier.", "body": "A tag identifies who applied it and why — but you cannot physically prevent a machine from starting with a tag. You can only ask.", "image": "img/s12-tags-vs-locks.jpg" },
+
+    { "type": "keypoint", "kicker": "The Actual Structure", "heading": "Two cases.\nTwo different rules.", "body": "Can't be locked out: tagout required, period. Can be locked out but employer chooses tagout anyway: employer must prove equivalent protection. Tags supplement locks. They don't replace them by default.", "source": { "citation": "29 CFR 1910.147(c)(2)(i), (c)(2)(ii)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(c)(2)(i)", "anchor": "(c)(2)(i): \"If an energy isolating device is not capable of being locked out, the employer's energy control program under paragraph (c)(1) of this section shall utilize a tagout system.\" / (c)(2)(ii): \"If an energy isolating device is capable of being locked out, the employer's energy control program under paragraph (c)(1) of this section shall utilize lockout, unless the employer can demonstrate that the utilization of a tagout system will provide full employee protection as set forth in paragraph (c)(3) of this section.\"" } },
+
+    { "type": "concept", "label": "Step Five — Stored Energy", "boxText": "New energy can't enter. But the energy already inside hasn't gone anywhere.", "body": "Hydraulic lines: bleed until zero. Suspended loads: lower or block. Springs: release carefully. Capacitors: discharge per procedure.", "image": "img/s09-stored-energy.jpg" },
+
+    { "type": "reveal", "kicker": "Reaccumulation", "heading": "Sometimes step five\nisn't a one-time check.", "body": "Pneumatics re-pressurize. Capacitors recharge. Hydraulic pressure creeps back. If that's possible here, verification continues for as long as the job takes.", "source": { "citation": "29 CFR 1910.147(d)(5)(ii)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(d)(5)(ii)", "anchor": "If there is a possibility of reaccumulation of stored energy to a hazardous level, verification of isolation shall be continued until the servicing or maintenance is completed, or until the possibility of such accumulation no longer exists." } },
+
+    { "type": "keypoint", "kicker": "Step Six — Verify", "heading": "Push the button.\nWait for the silence.", "body": "Try to start the machine. If nothing happens, the lockout is complete. If something does happen, stop — you missed something. Verification isn't trust. It's proof.", "image": "img/s10-verify.jpg" },
+
+    { "type": "list", "label": "Why People Skip It", "heading": "The Excuses", "items": [
+      { "num": "1.", "text": "<strong>\"It's quick.\"</strong> Five-minute fix. In and out." },
+      { "num": "2.", "text": "<strong>\"I've done it before.\"</strong> A hundred times. Nothing happened." },
+      { "num": "3.", "text": "<strong>\"It's already off.\"</strong> They pressed the stop button." },
+      { "num": "4.", "text": "<strong>\"No one's watching.\"</strong> End of shift, just want to go home." },
+      { "num": "5.", "text": "<strong>\"The last guy didn't either.\"</strong> And he's fine." }
+    ] },
+
+    { "type": "reveal", "kicker": "The Truth", "heading": "Most of the time,\nnothing bad happens.", "body": "That's the truth. But \"most of the time\" is not \"always.\" And the one time it isn't fine, there's no partial outcome." },
+
+    { "type": "keypoint", "kicker": "The Whole Point", "heading": "Simple enough that\nthere's no good reason\nnot to do it.", "body": "Every time. Even the five-minute jobs. Especially the five-minute jobs." },
+
+    { "type": "scene", "label": "Back to the Breaker Panel", "text": "The same breaker panel. The sign is gone. In its place: a padlock, a tag, properly filled out. The breaker physically cannot be flipped." },
+
+    { "type": "scene", "label": "Scene", "text": "Inside the machine. Gloved hands working steadily. Unhurried. They know the machine is safe because they made it safe." },
+
+    { "type": "reveal", "kicker": "The Only Difference", "heading": "A sign is a request.\nA lock is a fact.", "body": "Six steps. A few minutes. A padlock. Everyone goes home safe." },
+
+    { "type": "summary", "heading": "Module 2 — Key Concepts", "items": ["The six steps build on each other — each one handles what the previous step couldn't", "Prepare: identify all energy sources using the machine-specific procedure", "Shutdown: use normal stopping procedures, verify all movement has stopped", "Isolate: disconnect from every energy source, not just electrical", "Lock: one person, one lock, no master keys — your lock is your personal guarantee", "Stored energy: address what's left; where energy can build back, verification continues until the job is done", "Verify: try to start the machine — silence is proof", "Tags supplement locks but never replace them by default"] }
   ],
 
   "quiz": [
     {
-      "question": "What's the difference between a sign and a lock in LOTO procedures?",
-      "options": [
-        "Signs are permanent, locks are temporary",
-        "Signs inform about hazards, locks prevent operation",
-        "Signs are for electrical, locks are for mechanical",
-        "There is no difference — they serve the same purpose"
-      ],
+      "question": "Before beginning any lockout/tagout procedure, the first thing an authorized employee should do is:",
+      "options": ["Place a padlock on the main electrical disconnect", "Review the machine-specific lockout procedure to identify all energy sources and isolation points", "Notify their supervisor that they're beginning maintenance", "Turn off the machine using the stop button"],
       "correct": 1
     },
     {
-      "question": "Why is the 'Prepare for Shutdown' step important?",
-      "options": [
-        "It's required paperwork for legal compliance",
-        "It identifies all energy sources and lockout points before work begins",
-        "It delays the job to ensure workers are paid more",
-        "It's only necessary for new employees"
-      ],
+      "question": "Three workers are performing maintenance on the same piece of equipment. How many locks should be on the energy isolation point?",
+      "options": ["One lock — the lead worker applies it for the team", "Two locks — one from the team and one from the supervisor", "Three locks — each worker applies their own lock with their own key", "One lock with three keys, so any worker can remove it when they're done"],
+      "correct": 2
+    },
+    {
+      "question": "After completing steps 1 through 5 of the lockout procedure, the authorized employee should:",
+      "options": ["Begin maintenance work immediately since the machine is isolated and locked", "Attempt to energize the equipment using operating controls to verify the lockout is complete", "Have a supervisor inspect the lockout before proceeding", "Wait 15 minutes to ensure all stored energy has dissipated"],
       "correct": 1
     },
     {
-      "question": "In the 'One Person, One Lock' principle, when can you remove someone else's lock?",
-      "options": [
-        "When they give you permission",
-        "When you're the supervisor",
-        "When their shift ends",
-        "Never — each person removes only their own lock"
-      ],
-      "correct": 3
-    },
-    {
-      "question": "According to the module, who is most likely to skip LOTO procedures?",
-      "options": [
-        "New employees who don't know better",
-        "Experienced workers who think they know the equipment",
-        "Workers who don't have proper training",
-        "Employees working on simple tasks"
-      ],
-      "correct": 1
+      "question": "A maintenance worker needs to replace a sensor on a machine. It's a two-minute job, and the machine is already stopped. The worker decides to skip the lockout procedure because it would take longer than the repair. This decision is:",
+      "options": ["Reasonable — the procedure is designed for major maintenance, not quick fixes", "Acceptable if the worker stays alert and watches for hazards", "Dangerous — the procedure applies regardless of job duration, and short jobs are where complacency is highest", "Fine as long as another worker stands nearby as a spotter"],
+      "correct": 2
     }
   ]
 }

--- a/courses/loto/builds/module-02/index.html
+++ b/courses/loto/builds/module-02/index.html
@@ -676,7 +676,7 @@ html, body {
 
 /* Text shadow for body text over dark backgrounds - enhanced */
 .slide-keypoint .body,
-.slide-reveal .body, 
+.slide-reveal .body,
 .slide-concept .body,
 .slide-scene p,
 .slide-list .item-text,
@@ -684,6 +684,46 @@ html, body {
   text-shadow: 0 2px 12px rgba(0,0,0,0.8), 0 1px 3px rgba(0,0,0,0.9);
 }
 
+/* --- Citation chip (Reviewer mode) --- */
+.citation-chip {
+  position: absolute;
+  right: 2vw;
+  bottom: 1.5vh;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  letter-spacing: 0.03em;
+  color: var(--steel-dim);
+  background: rgba(42,42,42,0.72);
+  border: 1px solid var(--steel-blue);
+  border-radius: 4px;
+  padding: 0.4em 0.7em;
+  text-decoration: none;
+  backdrop-filter: blur(3px);
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+.citation-chip:hover {
+  color: var(--safety-yellow);
+  border-color: var(--safety-yellow);
+}
+.citation-chip-icon {
+  opacity: 0.8;
+}
+
+/* --- Learner/Reviewer toggle --- */
+.bottom-bar-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.mode-toggle-btn[aria-pressed="true"] {
+  background: var(--safety-yellow);
+  color: var(--bg-dark);
+  border-color: var(--safety-yellow);
+}
 
 
 
@@ -699,7 +739,10 @@ html, body {
   <div class="slide-container" id="slideContainer"></div>
 
   <div class="bottom-bar">
-    <a href="../index.html" class="nav-btn" style="margin-right: 2vw;">MENU</a>
+    <div class="bottom-bar-left">
+      <a href="../index.html" class="nav-btn">MENU</a>
+      <button class="nav-btn mode-toggle-btn" id="modeToggleBtn" onclick="toggleReviewerMode()" aria-pressed="false" title="Toggle citation view for review/compliance">Learner Mode</button>
+    </div>
     <div class="progress-section">
       <div class="progress-track">
         <div class="progress-fill" id="progressFill"></div>
@@ -715,94 +758,75 @@ html, body {
 
 <script>
 const MODULE = {
-  "title": "The Six Steps", 
+  "title": "The Six Steps",
   "moduleNumber": 2,
   "partLabel": "Part Two — The Procedure That Keeps You Alive",
   "passingScore": 75,
   "slides": [
-    { "type": "title", "moduleLabel": "Module 2", "heading": "The Six Steps", "subtitle": "Part Two — The Procedure That Keeps You Alive", "brand": "SOPs Nobody Reads" },
-    { "type": "scene", "label": "Cold Open", "text": "A breaker panel in a hallway. Someone has taped a handwritten sign next to one of the breakers: <em>\"DO NOT TURN ON — Mike working on Line 3.\"</em> The tape is peeling at one corner.", "image": "img/s01-handwritten-sign.jpg" },
-    { "type": "scene", "label": "Scene", "text": "A hand reaches past the sign and flips the breaker to ON. The sign flutters. The hand belongs to someone who didn't read it, or didn't think it applied to them.", "image": "img/s02-flips-breaker.jpg" },
-    { "type": "reveal", "kicker": "The Difference", "heading": "A sign is not a lock.\nA sign is a request.\nA lock is a fact.", "body": "And the difference between a request and a fact is the distance between going home tonight and not.", "image": "img/s03-sign-vs-lock.jpg" },
-    { "type": "keypoint", "kicker": "Why Order Matters", "heading": "Six steps.\nSix layers of protection.", "body": "Each step handles something the previous step couldn't. Skip a layer and there's a gap. A gap in this process is a gap in your protection.", "image": "img/s04-six-steps.jpg" },
-    { "type": "keypoint", "kicker": "Step 1", "heading": "Prepare for Shutdown", "body": "Find the machine-specific lockout procedure. Know what you're dealing with. Notify affected employees. This isn't paperwork — it's your map. Without it, you're guessing.", "image": "img/s05-prepare.jpg" },
-    { "type": "keypoint", "kicker": "Step 2", "heading": "Equipment Shutdown", "body": "Use normal stopping procedures. Verify all moving parts have actually stopped — not almost stopped, not slowing down. Stopped. Flywheels coast. Wait for zero.", "image": "img/s06-shutdown.jpg" },
-    { "type": "keypoint", "kicker": "Step 3", "heading": "Energy Isolation", "body": "Disconnect from every energy source. Electric, pneumatic, hydraulic, mechanical. Turn breakers to OFF. Close valves. Disconnect supply lines. Isolation means no energy can reach the equipment.", "image": "img/s07-isolate.jpg" },
-    { "type": "keypoint", "kicker": "Step 4", "heading": "Apply Lockout Devices", "body": "Lock every isolation point. One lock per person working on the equipment. Your lock, your key, your life. Remove only your own locks when your work is complete.", "image": "img/s08-lockout.jpg" },
-    { "type": "keypoint", "kicker": "Step 5", "heading": "Stored Energy Control", "body": "Relieve, disconnect, or restrain stored energy. Bleed air pressure. Discharge capacitors. Support suspended components. Release spring tension safely. Stored energy is patient — it waits.", "image": "img/s09-stored-energy.jpg" },
-    { "type": "keypoint", "kicker": "Step 6", "heading": "Verify Isolation", "body": "Test that the equipment cannot be operated. Try to start it using normal procedures. Check for movement, lights, sounds. Verify zero energy state before beginning work.", "image": "img/s10-verify.jpg" },
-    { "type": "concept", "label": "One Person, One Lock", "boxText": "Each worker applies their own lock and removes only their own lock.", "body": "Your lock protects you. Someone else's lock protects them. You never remove another person's lock. They never remove yours. This isn't bureaucracy — it's survival.", "image": "img/s11-one-person-one-lock.jpg" },
-    { "type": "concept", "label": "Tags vs. Locks", "boxText": "Tags inform. Locks prevent. Tags supplement locks — they never replace them.", "body": "A tag tells you who's working and why. But a tag won't stop someone from flipping a switch. Use both: lock to prevent, tag to inform.", "image": "img/s12-tags-vs-locks.jpg" },
-    { "type": "keypoint", "kicker": "Why People Skip Steps", "heading": "\"I've done this job\na hundred times.\"", "body": "Experience creates shortcuts. Familiarity breeds assumption. The worker who skips LOTO is usually the experienced one — the one who knows the machine, knows the work, knows it'll only take five minutes.", "image": "img/s13-experienced-worker.jpg" },
-    { "type": "reveal", "kicker": "The Psychology", "heading": "Every accident starts\nwith \"just this once.\"", "body": "Just this once I'll skip the lockout. Just this once I'll reach inside while it's running. Just this once I won't wait for the moving parts to stop. Experience makes you confident. Confidence makes you careless.", "image": "img/s14-just-this-once.jpg" },
-    { "type": "list", "label": "The Six Steps", "heading": "Every time. In order.", "items": [
-      { "num": "1.", "text": "<strong>Prepare:</strong> Review procedure, notify affected employees" },
-      { "num": "2.", "text": "<strong>Shutdown:</strong> Use normal stopping procedures, verify zero motion" },
-      { "num": "3.", "text": "<strong>Isolate:</strong> Disconnect from all energy sources" },
-      { "num": "4.", "text": "<strong>Lock:</strong> Apply lockout devices, one per person" },
-      { "num": "5.", "text": "<strong>Stored Energy:</strong> Relieve, disconnect, or restrain" },
-      { "num": "6.", "text": "<strong>Verify:</strong> Test that equipment cannot operate" }
-    ], "image": "img/s15-six-steps-complete.jpg" },
-    { "type": "summary", "heading": "Module 2 — Key Concepts", "items": [
-      "A lock is a fact, a sign is a request",
-      "Six steps create six layers of protection",
-      "One person, one lock — your lock protects your life", 
-      "Tags inform, locks prevent — use both",
-      "Experience creates dangerous shortcuts",
-      "Every accident starts with 'just this once'",
-      "Everyone goes home safe"
-    ] }
+    {"type": "title", "moduleLabel": "Module 2", "heading": "The Six Steps", "subtitle": "Part Two — The Procedure That Keeps You Alive", "brand": "SOPs Nobody Reads"},
+    {"type": "scene", "label": "Cold Open", "text": "A breaker panel in a hallway. A handwritten sign: \"DO NOT TURN ON — Mike working on Line 3.\" A hand reaches past it and flips the breaker to ON."},
+    {"type": "reveal", "kicker": "The Difference", "heading": "A sign is not\na lock.", "body": "A sign is a request. A lock is a fact. And the difference between a request and a fact is the distance between going home tonight and not."},
+    {"type": "keypoint", "kicker": "Why Order Matters", "heading": "Six steps.\nEach one closes\na different gap.", "body": "Each step handles something the previous step couldn't. Skip a layer and there's a gap. A gap in this process is a gap in your protection."},
+    {"type": "concept", "label": "Step One — Prepare", "boxText": "Find the machine-specific lockout procedure — every energy source, where it enters, what device isolates it.", "body": "This is the step most people skip. It feels like paperwork. But this form is the map. Guessing gets people hurt.", "image": "img/s05-prepare.jpg"},
+    {"type": "keypoint", "kicker": "Also Step One", "heading": "Notify everyone\naffected.", "body": "What's being locked out. Why. How long. Who's responsible. An affected employee who doesn't know about the lockout might try to start the machine."},
+    {"type": "keypoint", "kicker": "Step Two — Shutdown", "heading": "Wait for zero.\nNot \"almost stopped.\"", "body": "Flywheels coast. Gears have momentum. Use the normal stopping procedure — the one documented, the one you were trained on. Don't improvise.", "image": "img/s06-shutdown.jpg"},
+    {"type": "concept", "label": "Step Three — Isolate", "boxText": "Disconnect from every energy source. Not just electrical.", "body": "Electrical: disconnect to OFF, verify breaker connections open. Hydraulic/pneumatic: valves CLOSED. Chemical: valves closed, lines bled or capped. The word is isolate, not reduce.", "image": "img/s07-isolate.jpg"},
+    {"type": "keypoint", "kicker": "Step Four — Lock", "heading": "The physical barrier.\nOnly you have the key.", "body": "Once this lock is on, the disconnect cannot move to ON. Not by accident. Not by anyone, for any reason, unless they have the key.", "image": "img/s08-lockout.jpg"},
+    {"type": "concept", "label": "One Person, One Lock", "boxText": "Each worker applies their own lock. Each lock has one key.", "body": "If three people are working on the machine, three locks go on. No one removes someone else's lock — ever, except through one narrow, employer-directed emergency procedure (Module 3)."},
+    {"type": "reveal", "kicker": "Why No Master Keys", "heading": "Your lock.\nYour key.\nYour guarantee.", "body": "Not a regulation's phrase — a design principle. A master key means someone else can override your decision that the machine isn't safe yet. Your life, someone else's judgment. That's not a system. That's a gamble."},
+    {"type": "concept", "label": "Tags vs. Locks", "boxText": "A tag is a communication device. A lock is a physical barrier.", "body": "A tag identifies who applied it and why — but you cannot physically prevent a machine from starting with a tag. You can only ask.", "image": "img/s12-tags-vs-locks.jpg"},
+    {"type": "keypoint", "kicker": "The Actual Structure", "heading": "Two cases.\nTwo different rules.", "body": "Can't be locked out: tagout required, period. Can be locked out but employer chooses tagout anyway: employer must prove equivalent protection. Tags supplement locks. They don't replace them by default.", "source": {"citation": "29 CFR 1910.147(c)(2)(i), (c)(2)(ii)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(c)(2)(i)", "anchor": "(c)(2)(i): \"If an energy isolating device is not capable of being locked out, the employer's energy control program under paragraph (c)(1) of this section shall utilize a tagout system.\" / (c)(2)(ii): \"If an energy isolating device is capable of being locked out, the employer's energy control program under paragraph (c)(1) of this section shall utilize lockout, unless the employer can demonstrate that the utilization of a tagout system will provide full employee protection as set forth in paragraph (c)(3) of this section.\""}},
+    {"type": "concept", "label": "Step Five — Stored Energy", "boxText": "New energy can't enter. But the energy already inside hasn't gone anywhere.", "body": "Hydraulic lines: bleed until zero. Suspended loads: lower or block. Springs: release carefully. Capacitors: discharge per procedure.", "image": "img/s09-stored-energy.jpg"},
+    {"type": "reveal", "kicker": "Reaccumulation", "heading": "Sometimes step five\nisn't a one-time check.", "body": "Pneumatics re-pressurize. Capacitors recharge. Hydraulic pressure creeps back. If that's possible here, verification continues for as long as the job takes.", "source": {"citation": "29 CFR 1910.147(d)(5)(ii)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(d)(5)(ii)", "anchor": "If there is a possibility of reaccumulation of stored energy to a hazardous level, verification of isolation shall be continued until the servicing or maintenance is completed, or until the possibility of such accumulation no longer exists."}},
+    {"type": "keypoint", "kicker": "Step Six — Verify", "heading": "Push the button.\nWait for the silence.", "body": "Try to start the machine. If nothing happens, the lockout is complete. If something does happen, stop — you missed something. Verification isn't trust. It's proof.", "image": "img/s10-verify.jpg"},
+    {"type": "list", "label": "Why People Skip It", "heading": "The Excuses", "items": [{"num": "1.", "text": "<strong>\"It's quick.\"</strong> Five-minute fix. In and out."}, {"num": "2.", "text": "<strong>\"I've done it before.\"</strong> A hundred times. Nothing happened."}, {"num": "3.", "text": "<strong>\"It's already off.\"</strong> They pressed the stop button."}, {"num": "4.", "text": "<strong>\"No one's watching.\"</strong> End of shift, just want to go home."}, {"num": "5.", "text": "<strong>\"The last guy didn't either.\"</strong> And he's fine."}]},
+    {"type": "reveal", "kicker": "The Truth", "heading": "Most of the time,\nnothing bad happens.", "body": "That's the truth. But \"most of the time\" is not \"always.\" And the one time it isn't fine, there's no partial outcome."},
+    {"type": "keypoint", "kicker": "The Whole Point", "heading": "Simple enough that\nthere's no good reason\nnot to do it.", "body": "Every time. Even the five-minute jobs. Especially the five-minute jobs."},
+    {"type": "scene", "label": "Back to the Breaker Panel", "text": "The same breaker panel. The sign is gone. In its place: a padlock, a tag, properly filled out. The breaker physically cannot be flipped."},
+    {"type": "scene", "label": "Scene", "text": "Inside the machine. Gloved hands working steadily. Unhurried. They know the machine is safe because they made it safe."},
+    {"type": "reveal", "kicker": "The Only Difference", "heading": "A sign is a request.\nA lock is a fact.", "body": "Six steps. A few minutes. A padlock. Everyone goes home safe."},
+    {"type": "summary", "heading": "Module 2 — Key Concepts", "items": ["The six steps build on each other — each one handles what the previous step couldn't", "Prepare: identify all energy sources using the machine-specific procedure", "Shutdown: use normal stopping procedures, verify all movement has stopped", "Isolate: disconnect from every energy source, not just electrical", "Lock: one person, one lock, no master keys — your lock is your personal guarantee", "Stored energy: address what's left; where energy can build back, verification continues until the job is done", "Verify: try to start the machine — silence is proof", "Tags supplement locks but never replace them by default"]},
   ],
   "quiz": [
-    {
-      "question": "What's the difference between a sign and a lock in LOTO procedures?",
-      "options": [
-        "Signs are permanent, locks are temporary",
-        "Signs inform about hazards, locks prevent operation",
-        "Signs are for electrical, locks are for mechanical",
-        "There is no difference — they serve the same purpose"
-      ],
-      "correct": 1
-    },
-    {
-      "question": "Why is the 'Prepare for Shutdown' step important?",
-      "options": [
-        "It's required paperwork for legal compliance",
-        "It identifies all energy sources and lockout points before work begins",
-        "It delays the job to ensure workers are paid more",
-        "It's only necessary for new employees"
-      ],
-      "correct": 1
-    },
-    {
-      "question": "In the 'One Person, One Lock' principle, when can you remove someone else's lock?",
-      "options": [
-        "When they give you permission",
-        "When you're the supervisor",
-        "When their shift ends",
-        "Never — each person removes only their own lock"
-      ],
-      "correct": 3
-    },
-    {
-      "question": "According to the module, who is most likely to skip LOTO procedures?",
-      "options": [
-        "New employees who don't know better",
-        "Experienced workers who think they know the equipment",
-        "Workers who don't have proper training",
-        "Employees working on simple tasks"
-      ],
-      "correct": 1
-    }
+    {"question": "Before beginning any lockout/tagout procedure, the first thing an authorized employee should do is:", "options": ["Place a padlock on the main electrical disconnect", "Review the machine-specific lockout procedure to identify all energy sources and isolation points", "Notify their supervisor that they're beginning maintenance", "Turn off the machine using the stop button"], "correct": 1},
+    {"question": "Three workers are performing maintenance on the same piece of equipment. How many locks should be on the energy isolation point?", "options": ["One lock — the lead worker applies it for the team", "Two locks — one from the team and one from the supervisor", "Three locks — each worker applies their own lock with their own key", "One lock with three keys, so any worker can remove it when they're done"], "correct": 2},
+    {"question": "After completing steps 1 through 5 of the lockout procedure, the authorized employee should:", "options": ["Begin maintenance work immediately since the machine is isolated and locked", "Attempt to energize the equipment using operating controls to verify the lockout is complete", "Have a supervisor inspect the lockout before proceeding", "Wait 15 minutes to ensure all stored energy has dissipated"], "correct": 1},
+    {"question": "A maintenance worker needs to replace a sensor on a machine. It's a two-minute job, and the machine is already stopped. The worker decides to skip the lockout procedure because it would take longer than the repair. This decision is:", "options": ["Reasonable — the procedure is designed for major maintenance, not quick fixes", "Acceptable if the worker stays alert and watches for hazards", "Dangerous — the procedure applies regardless of job duration, and short jobs are where complacency is highest", "Fine as long as another worker stands nearby as a spotter"], "correct": 2}
   ]
 };
 
-// Player JavaScript (same as Module 1, no modifications needed)
+// Player JavaScript (same as AI onboarding, no modifications needed)
 let currentSlide = 0;
 let quizAnswers = [];
 let quizMode = false;
 let currentQuizQuestion = 0;
 let isAnswered = false;
+
+// Reviewer mode: view state only, in-memory for this session. NOT persisted
+// (no localStorage) — this player gets packaged for SCORM/LMS delivery, and
+// LMS iframe storage-partitioning makes localStorage unreliable inside an SCO.
+// Never touches SCORM/LMS calls or completion/score tracking.
+let reviewerMode = false;
+
+function toggleReviewerMode() {
+  reviewerMode = !reviewerMode;
+  const btn = document.getElementById('modeToggleBtn');
+  btn.textContent = reviewerMode ? 'Reviewer Mode' : 'Learner Mode';
+  btn.setAttribute('aria-pressed', String(reviewerMode));
+  renderSlide();
+}
+
+// Returns citation chip HTML, or '' if reviewer mode is off or the source
+// is missing/incomplete. Fail-safe: never renders a partial or fabricated
+// citation — citation and url are both required.
+function renderCitation(source) {
+  if (!reviewerMode || !source || !source.citation || !source.url) return '';
+  return `
+    <a class="citation-chip" href="${source.url}" target="_blank" rel="noopener">
+      <span class="citation-chip-icon">&sect;</span>${source.citation}
+    </a>
+  `;
+}
 
 function initPlayer() {
   renderSlide();
@@ -936,9 +960,11 @@ function renderSlide() {
       `;
       break;
   }
-  
+
+  html += renderCitation(slide.source);
+
   container.innerHTML = html;
-  
+
   // Activate the slide
   setTimeout(() => {
     const slideEl = container.querySelector('.slide');
@@ -987,7 +1013,7 @@ function renderQuiz() {
     `;
   }
   
-  const html = `
+  let html = `
     <div class="slide slide-quiz active">
       <div class="quiz-container">
         <h2>Question ${currentQuizQuestion + 1}</h2>
@@ -1001,7 +1027,9 @@ function renderQuiz() {
       </div>
     </div>
   `;
-  
+
+  html += renderCitation(question.source);
+
   container.innerHTML = html;
 }
 
@@ -1016,10 +1044,10 @@ function selectAnswer(answerIndex) {
 
 function getQuizFeedback(questionIndex) {
   const feedbacks = [
-    "Signs inform about hazards, while locks physically prevent operation of equipment.",
-    "The Prepare step identifies all energy sources and lockout points before work begins, providing a safety map.",
-    "In the 'One Person, One Lock' principle, each person removes only their own lock to maintain individual protection.",
-    "Experienced workers are most likely to skip procedures due to overconfidence and familiarity with equipment."
+    "Guessing which energy sources are present and where to isolate them is how people get hurt. The machine-specific procedure is the map — it comes first.",
+    "One person, one lock. Three workers means three locks, each removable only by the person who applied it.",
+    "Verification isn't trust — it's proof. Attempting to energize the equipment is the only way to confirm the lockout actually worked.",
+    "The procedure applies regardless of job duration. Short jobs are exactly where complacency is highest — the same reasoning that gets people hurt."
   ];
   return feedbacks[questionIndex] || '';
 }
@@ -1047,7 +1075,7 @@ function renderResults() {
           <a href="../module-03/index.html" class="nav-btn">Next Module &#8594;</a>
         </div>
         <p style="margin-top: 3vh; font-size: 0.9rem; color: var(--steel-dim);">
-          Module 2 of 3 &mdash; Continue to the final module on complex LOTO situations.
+          Module 2 of 3 &mdash; Continue to Module 3: When Simple Gets Complicated.
         </p>
       </div>
     </div>

--- a/courses/loto/builds/module-03-image-manifest.md
+++ b/courses/loto/builds/module-03-image-manifest.md
@@ -1,0 +1,49 @@
+# Module 3 — Slide → Image Manifest
+
+Built against the regenerated `module-03.json` (31 slides), Phase 4b of the LOTO Pass-4 rework. Every candidate below was opened and visually checked against the new slide content — not filename-matched.
+
+## Reused (8 images — visually verified)
+
+| Slide | Content | Image | Note |
+|---|---|---|---|
+| 2 | Cold open — shift change | `s01-shift-change.jpg` | Workers walking through a shift-change doorway, warm backlight. Clean, no text. |
+| 3 | The Gap | `s02-gap-in-protection.jpg` | Closed, unlocked disconnect box; workers visible through a doorway in the background. Clean. |
+| 5 | The Critical Ones (restoring equipment) | `s06-headcount.jpg` | Coordinator with clipboard, three workers raising hands — a literal headcount. Strong match. |
+| 6 | Group Lockout | `s07-multiple-locks.jpg` | Four colored padlocks on one hasp, no text. Matches "each worker applies their own lock" well (script says five; four reads close enough, not a contradiction). |
+| 7 | The Lockbox Method | `s09-lockbox-method.jpg` | Open lockbox with a key inside, three padlocks on the box. Excellent match, no text. |
+| 8 | Shift Changes — Solution (overlap) | `s10-shift-overlap.jpg` | Two locks on one hasp together — visually IS the overlap concept. Strong match. |
+| 14 | Emergency Lock Removal | `s11-emergency-removal.jpg` | Single padlock on a disconnect, quiet empty facility, pliers on a workbench. Strong match, no text. |
+| 29 | Callback closing / course recap | `s15-course-complete.jpg` | Worker walking away through a doorway, padlock on belt, dozens of padlocks visible on a panel. Strong symbolic close, no text. |
+
+## Rejected — do not reuse
+
+| Old file | Problem |
+|---|---|
+| `s12-roles.jpg` | **Explicitly flagged in the brief.** Shows **four** workers standing in concentric circles (orange/blue/yellow/white gear) — this is the old four-role diagram. The corrected script teaches **three** roles (authorized/affected/other) plus the qualified-person reframe. This image now asserts the exact error Phase 4 corrected. Must be regenerated as a three-ring diagram, not relabeled. |
+| `s13-documentation.jpg` | Clipboard header reads **"LOCKLOUT TAG..."** — garbled ("LOCKOUT" misspelled with a doubled L), plus illegible scribbled handwriting in the body. Same defect class as Module 2's findings. The padlock in the same image is legibly labeled "LOCKOUT" (correct) but the clipboard's garbled header makes the overall asset unsafe to ship. |
+| `s04-seven-steps.jpg` | Footprints on a factory floor — atmospheric, doesn't convey a seven-item list. Weak match for the "Restoring Equipment" list slide. |
+
+## Not individually viewed this pass
+
+`s03-four-minutes.jpg`, `s05-restoration-checklist.jpg`, `s08-coordinator.jpg`, `s14-complete-system.jpg` — not checked this pass given scope; default to NEW rather than assumed-reusable until visually verified.
+
+## NEW — needs generation (at minimum, per the brief)
+
+| Slide | Content | Why new |
+|---|---|---|
+| 18 | **Three-role concentric diagram** (was four) | **Explicitly flagged in the brief.** `s12-roles.jpg` shows the old four-person version — needs full regeneration as three rings, not a relabel. Highest priority: this is the module's visual thesis for the reframe. |
+| 10 | **Cord-and-plug** — hand on the plug, not the tool | **Explicitly flagged in the brief.** New scope-exclusion content from Phase 4a; no prior art exists at all. |
+| 11 | **Minor-servicing** — purpose-built clearing tool in use | **Explicitly flagged in the brief.** Same — brand new content. |
+| 13 | **Testing/positioning** — five-step ordered sequence diagram | **Explicitly flagged in the brief.** Same — brand new content, procedural diagram treatment (same style as the six-steps/seven-steps visuals). |
+| 4 | Restoring Equipment — seven-step list | `s04` rejected (footprints, weak match) |
+| 16 | Emergency removal — three-elements list | No existing equivalent verified this pass |
+
+## No image needed by design (remaining slides)
+
+Typography-forward per the script's own tone notes ("When the standard flexes: precise, a little stern... no hedging"), or conventionally image-less types (title, list, summary, regulatory-quote slides matching M1's citation-slide convention): slides 1 (title), 9 (flexes intro), 12 (minor-servicing misuse reinforcement), 15 (not a coworker's call — source-citation slide), 17 (why notification matters), 19 (three roles intro — source-citation slide), 20 (authorized employees), 21 (affected employees), 22 (other employees — source-citation slide), 23 (qualified-person reframe — source-citation slide), 24 (different standard, different question), 25 (paperwork reframed), 26 (contractors info exchange — source-citation slide), 27 (paperwork thesis), 30 (course-in-one-line recap), 31 (summary).
+
+## Priority for the next image-generation pass
+
+1. **The three-role diagram (slide 18)** — top priority. This is both the module's stated visual thesis and the one place where shipping the *old* image would actively re-teach the error this whole phase corrected.
+2. **The three "When the Standard Flexes" panels (slides 10, 11, 13)** — brand new content with zero prior art; currently these three load-bearing slides fall back to gradient backgrounds.
+3. Everything else, as budget allows.

--- a/courses/loto/builds/module-03.json
+++ b/courses/loto/builds/module-03.json
@@ -1,101 +1,106 @@
 {
   "title": "When Simple Gets Complicated",
-  "moduleNumber": 3, 
+  "moduleNumber": 3,
   "partLabel": "Part Three — The Edge Cases",
   "passingScore": 75,
 
   "slides": [
     { "type": "title", "moduleLabel": "Module 3", "heading": "When Simple\nGets Complicated", "subtitle": "Part Three — The Edge Cases", "brand": "SOPs Nobody Reads" },
-    
-    { "type": "scene", "label": "Cold Open", "text": "Shift change. The outgoing crew walks toward the exit. One of them pulls a lock off a disconnect on their way out. Casual. Done for the day.", "image": "img/s01-shift-change.jpg" },
-    
-    { "type": "scene", "label": "Scene", "text": "The disconnect has no lock now. The incoming crew is still in the break room getting briefed. For the next four minutes, this machine is unprotected.", "image": "img/s02-gap-in-protection.jpg" },
-    
-    { "type": "reveal", "kicker": "The Gap", "heading": "Four minutes.\nThat's the gap between\none crew's safety and the next.", "body": "And in that gap, anyone could start this machine. Shift change creates vulnerability unless managed properly.", "image": "img/s03-four-minutes.jpg" },
-    
-    { "type": "keypoint", "kicker": "Restoring Equipment", "heading": "Seven steps to\nbring it back safely", "body": "You've locked the machine out. You've done the work. Now it's time to restore the equipment. This has its own sequence, and it matters as much as the lockout itself.", "image": "img/s04-seven-steps.jpg" },
-    
-    { "type": "list", "label": "Restoration Steps", "heading": "In this order. Every time.", "items": [
-      { "num": "1.", "text": "<strong>Inspect:</strong> Work is finished, all tools accounted for" },
-      { "num": "2.", "text": "<strong>Clean up:</strong> Parts, rags, work aids back where they belong" },
-      { "num": "3.", "text": "<strong>Replace guards:</strong> Every guard back before machine starts" },
-      { "num": "4.", "text": "<strong>Check controls:</strong> Everything in neutral or safest position" },
-      { "num": "5.", "text": "<strong>Check for personnel:</strong> All workers verified clear and notified" },
-      { "num": "6.", "text": "<strong>Remove your lock:</strong> Only your lock. Not someone else's." },
-      { "num": "7.", "text": "<strong>Re-energize:</strong> Follow manufacturer's startup procedures" }
-    ], "image": "img/s05-restoration-checklist.jpg" },
-    
-    { "type": "concept", "label": "Check for Personnel", "boxText": "This is not a glance. This is a headcount.", "body": "If three people were working on this machine, three people must be verified clear before any lock comes off. Every person who was working must be accounted for and notified.", "image": "img/s06-headcount.jpg" },
-    
-    { "type": "keypoint", "kicker": "Group Lockout", "heading": "Multiple workers,\nmultiple locks", "body": "When multiple workers need to service the same equipment, each one applies their own lock. The principle scales: one person, one lock. The machine cannot restart until the last lock is off.", "image": "img/s07-multiple-locks.jpg" },
-    
-    { "type": "concept", "label": "Group Coordinator", "boxText": "Someone needs to be in charge. One authorized employee manages the overall lockout.", "body": "They don't replace individual locks. They organize the process, review procedures with everyone, and coordinate the work.", "image": "img/s08-coordinator.jpg" },
-    
-    { "type": "keypoint", "kicker": "Lockbox Method", "heading": "What if there's only\nroom for one lock?", "body": "One lock goes on the disconnect. The key to that lock goes inside a lockbox. Each worker puts their own lock on the lockbox. The machine can't start until every worker removes their lock from the box.", "image": "img/s09-lockbox-method.jpg" },
-    
-    { "type": "keypoint", "kicker": "Shift Change Protocol", "heading": "Continuous protection\nacross shift changes", "body": "The incoming crew applies their locks before the outgoing crew removes theirs. Overlap protection. The machine is never unprotected, not even for minutes.", "image": "img/s10-shift-overlap.jpg" },
-    
-    { "type": "keypoint", "kicker": "Emergency Lock Removal", "heading": "When someone leaves\ntheir lock behind", "body": "This requires special authorization. The absent employee must be contacted and verified. Management approval required. All affected personnel notified. This is not a casual decision.", "image": "img/s11-emergency-removal.jpg" },
-    
-    { "type": "concept", "label": "Roles and Responsibility", "boxText": "Authorized employee: Can apply and remove locks, coordinate group lockout. Affected employee: Notified of lockout, must stay clear.", "body": "Each role has specific responsibilities. Know which role you're in for each lockout situation. Authority matters. Clear communication matters.", "image": "img/s12-roles.jpg" },
-    
-    { "type": "keypoint", "kicker": "The Paperwork Reframe", "heading": "Documentation isn't\nbureaucracy", "body": "It's memory. Who's working where. What energy sources are controlled. When the work started. When it ended. When someone gets hurt, this documentation explains what went right and what went wrong.", "image": "img/s13-documentation.jpg" },
-    
-    { "type": "reveal", "kicker": "The Complete Picture", "heading": "LOTO isn't just\na six-step procedure", "body": "It's a comprehensive system. Individual lockout. Group lockout. Shift change protocols. Emergency procedures. Documentation. Each element protects against specific failure modes.", "image": "img/s14-complete-system.jpg" },
-    
-    { "type": "keypoint", "kicker": "Course Complete", "heading": "You now understand\nthe energy you don't see", "body": "Five types of hazardous energy. Six steps to control them. Protocols for complex situations. The tools to protect yourself and your coworkers. Two minutes and a padlock. That's all it takes.", "image": "img/s15-course-complete.jpg" },
-    
-    { "type": "summary", "heading": "LOTO Course — Key Concepts", "items": [
-      "LOTO is a comprehensive system, not just a procedure",
-      "Group lockout scales the one-person-one-lock principle",
-      "Lockbox method handles single-lock situations", 
-      "Shift change requires overlap protection",
-      "Emergency lock removal needs special authorization",
-      "Documentation provides memory and accountability",
-      "Everyone goes home safe — every shift, every day"
-    ] }
+
+    { "type": "scene", "label": "Cold Open", "text": "Shift change. A factory floor, afternoon bleeding into evening. The outgoing crew pulls their lock and heads for the exit.", "image": "img/s01-shift-change.jpg" },
+
+    { "type": "concept", "label": "The Gap", "boxText": "For the next four minutes, this machine is unprotected.", "body": "The outgoing crew pulled their locks. The incoming crew hasn't applied theirs yet. In that gap, anyone could start this machine.", "image": "img/s02-gap-in-protection.jpg" },
+
+    { "type": "list", "label": "Before the Edge Cases", "heading": "Restoring Equipment — Seven Steps", "items": [
+      { "num": "1.", "text": "<strong>Inspect.</strong> Make sure the work is actually finished." },
+      { "num": "2.", "text": "<strong>Clean up.</strong> Parts, rags, work aids back where they belong." },
+      { "num": "3.", "text": "<strong>Replace guards.</strong> Every guard goes back before startup." },
+      { "num": "4.", "text": "<strong>Check controls.</strong> Everything in neutral or its safest position." },
+      { "num": "5.", "text": "<strong>Check for personnel.</strong> A headcount, not a glance." },
+      { "num": "6.", "text": "<strong>Remove your lock.</strong> Only yours." },
+      { "num": "7.", "text": "<strong>Re-energize.</strong> Follow the documented startup sequence." }
+    ] },
+
+    { "type": "keypoint", "kicker": "The Critical Ones", "heading": "Check for personnel.\nRemove your lock.\nRe-energize.", "body": "This is a headcount, not a glance. Your lock — not someone else's. Follow the manufacturer's startup sequence, not the reverse of shutdown.", "image": "img/s06-headcount.jpg" },
+
+    { "type": "concept", "label": "Group Lockout", "boxText": "One worker, one machine, one lock — the principle scales.", "body": "A group coordinator manages the process without replacing individual locks. Each worker applies their own. The machine can't restart until the last lock is off.", "image": "img/s07-multiple-locks.jpg" },
+
+    { "type": "keypoint", "kicker": "The Lockbox Method", "heading": "One lock on the machine.\nThe key goes in a box.\nEveryone locks the box.", "body": "The machine can't restart until the lockbox opens. The lockbox can't open until every worker removes their lock. Same protection. Different geometry.", "image": "img/s09-lockbox-method.jpg" },
+
+    { "type": "reveal", "kicker": "The Solution", "heading": "New lock on.\nThen old lock off.", "body": "The incoming worker's lock goes on while the outgoing worker's lock is still there. At no point is the hasp empty. At no point is the machine unprotected.", "image": "img/s10-shift-overlap.jpg" },
+
+    { "type": "keypoint", "kicker": "Three Edge Cases", "heading": "Written into the standard,\nnot made up to save time.", "body": "Places where the standard draws its own boundaries. Learn them as boundaries, not shortcuts." },
+
+    { "type": "concept", "label": "Cord-and-Plug Equipment", "boxText": "Unplugged AND under your exclusive control — both, not one.", "body": "A bench grinder. A portable drill. If the plug stays in your hand, your pocket, your sight the whole time, this standard doesn't require lockout on it.", "source": { "citation": "29 CFR 1910.147(a)(2)(iii)(A)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(a)(2)(iii)(A)", "anchor": "Work on cord and plug connected electric equipment for which exposure to the hazards of unexpected energization or start up of the equipment is controlled by the unplugging of the equipment from the energy source and by the plug being under the exclusive control of the employee performing the servicing or maintenance." } },
+
+    { "type": "reveal", "kicker": "The Most Misused Exception", "heading": "Minor servicing —\nread the fence twice.", "body": "Normal production operations. Routine. Repetitive. Integral to production. Alternative measures providing effective protection. All of it. Every time.", "source": { "citation": "29 CFR 1910.147(a)(2)(ii), Note", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(a)(2)(ii)", "anchor": "Exception to paragraph (a)(2)(ii): Minor tool changes and adjustments, and other minor servicing activities, which take place during normal production operations, are not covered by this standard if they are routine, repetitive, and integral to the use of the equipment for production, provided that the work is performed using alternative measures which provide effective protection (See subpart O of this part)." } },
+
+    { "type": "keypoint", "kicker": "Not a Badge You Assume", "heading": "\"Clearing a jam\"\nis the classic misuse.", "body": "If your alternative measure isn't actually providing effective protection, you don't have an exception. You have an unprotected worker near a hazard." },
+
+    { "type": "concept", "label": "Testing / Positioning", "boxText": "An exact sequence, in order — not an ad-hoc override.", "body": "Clear tools and personnel. Remove LOTO devices. Energize, test or position. De-energize, reapply LOTO. Same discipline as the six steps.", "source": { "citation": "29 CFR 1910.147(f)(1)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(f)(1)", "anchor": "In situations in which lockout or tagout devices must be temporarily removed from the energy isolating device and the machine or equipment energized to test or position the machine, equipment or component thereof, the following sequence of actions shall be followed:" } },
+
+    { "type": "scene", "label": "Emergency Lock Removal", "text": "A disconnect with a single lock. Shift's over. The person whose lock this is? Gone. Not answering their phone.", "image": "img/s11-emergency-removal.jpg" },
+
+    { "type": "concept", "label": "Not a Coworker's Call", "boxText": "Only under the employer's direction, through a procedure documented in advance.", "body": "Nobody improvises this in the moment.", "source": { "citation": "29 CFR 1910.147(e)(3)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(e)(3)", "anchor": "Exception to paragraph (e)(3): When the authorized employee who applied the lockout or tagout device is not available to remove it, that device may be removed under the direction of the employer, provided that specific procedures and training for such removal have been developed, documented and incorporated into the employer's energy control program." } },
+
+    { "type": "list", "label": "The Documented Procedure", "heading": "Three Elements", "items": [
+      { "num": "1.", "text": "<strong>Verify the employee is absent.</strong> Not in the building, not on break." },
+      { "num": "2.", "text": "<strong>Make reasonable efforts to contact them.</strong> Document the attempts." },
+      { "num": "3.", "text": "<strong>Inform them before they return.</strong> Before they approach any equipment." }
+    ] },
+
+    { "type": "reveal", "kicker": "Why Notification Matters", "heading": "The lock removal isn't\ncomplete until they know.", "body": "A worker returning to a machine they think is locked out, reaching in confident — that's the alternative this requirement prevents." },
+
+    { "type": "concept", "label": "Three Roles — 29 CFR 1910.147(b)", "boxText": "Authorized. Affected. Other.", "body": "Each role carries different responsibilities, different training, different obligations.", "source": { "citation": "29 CFR 1910.147(b)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(b)", "anchor": "Affected employee.   An employee whose job requires him/her to operate or use a machine or equipment on which servicing or maintenance is being performed under lockout or tagout, or whose job requires him/her to work in an area in which such servicing or maintenance is being performed. / Authorized employee.   A person who locks out or tags out machines or equipment in order to perform servicing or maintenance on that machine or equipment." } },
+
+    { "type": "keypoint", "kicker": "Authorized Employees", "heading": "They perform\nthe lockout.", "body": "Trained on every energy source, every isolation point. They apply the locks. They verify the isolation." },
+
+    { "type": "keypoint", "kicker": "Affected Employees", "heading": "Their work is affected —\nthey don't perform it.", "body": "An operator whose line is shut down for maintenance. Their job: never attempt to restart locked-out equipment. Ever." },
+
+    { "type": "concept", "label": "Other Employees", "boxText": "Basic awareness training.", "body": "Lockout exists. Locked-out equipment is off-limits. Attempting to start it can kill the person inside.", "source": { "citation": "29 CFR 1910.147(c)(7)(i)(A), (B), (C)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(c)(7)(i)(A)", "anchor": "(A) Each authorized employee shall receive training in the recognition of applicable hazardous energy sources, the type and magnitude of the energy available in the workplace, and the methods and means necessary for energy isolation and control. / (B) Each affected employee shall be instructed in the purpose and use of the energy control procedure. / (C) All other employees whose work operations are or may be in an area where energy control procedures may be utilized, shall be instructed about the procedure, and about the prohibition relating to attempts to restart or reenergize machines or equipment which are locked out or tagged out." } },
+
+    { "type": "reveal", "kicker": "Real Term, Wrong Standard", "heading": "\"Qualified person\"\nisn't a fourth role.", "body": "It's a real OSHA term — just not from this standard. It means trained to work on or near exposed energized electrical parts.", "source": { "citation": "29 CFR 1910.399, \"Qualified person\"", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-S/subject-group-ECFR314553c63ae81f4/section-1910.399", "anchor": "Qualified person.   One who has received training in and has demonstrated skills and knowledge in the construction and operation of electric equipment and installations and the hazards involved." } },
+
+    { "type": "keypoint", "kicker": "Different Standard, Different Question", "heading": "Not \"what's your job\nhere\" — \"are you trained\nfor live electrical work.\"", "body": "A qualified person might also be an authorized employee on a lockout. Those aren't mutually exclusive. But qualified person answers a different question." },
+
+    { "type": "concept", "label": "The Forms, Reframed", "boxText": "Not bureaucracy. Evidence.", "body": "The procedure form is the map. The training certification is proof you were taught this. The inspection certification is proof someone verified it." },
+
+    { "type": "keypoint", "kicker": "Outside Contractors", "heading": "An information exchange.\nNot a certificate.", "body": "The on-site and outside employer inform each other of their procedures. A conversation, not a document either side signs and files.", "source": { "citation": "29 CFR 1910.147(f)(2)(i)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(f)(2)(i)", "anchor": "Whenever outside servicing personnel are to be engaged in activities covered by the scope and application of this standard, the on-site employer and the outside employer shall inform each other of their respective lockout or tagout procedures." } },
+
+    { "type": "reveal", "kicker": "The Thesis", "heading": "Every piece of paper\nexists because someone\nwas hurt by its absence.", "body": "The paperwork isn't bureaucracy. It's evidence that the system worked and everyone goes home safe." },
+
+    { "type": "scene", "label": "Back to Shift Change", "text": "The same factory floor. Shift change. But now the handoff is different." },
+
+    { "type": "scene", "label": "Scene", "text": "The incoming worker inside the machine. Working steadily. The lock visible in the background. Protection in place." },
+
+    { "type": "reveal", "kicker": "Same Shift Change", "heading": "The difference is\nthirty seconds\nand a padlock.", "body": "The procedure is simple. The edge cases are manageable. The paperwork has a purpose. The principle never changes — it just adapts.", "image": "img/s15-course-complete.jpg" },
+
+    { "type": "keypoint", "kicker": "The Course, In One Line", "heading": "Six sources.\nSix steps.\nThree roles.", "body": "Six named energy sources, each with its own stored-energy shadow. Six steps that turn off into safe. Three roles, each with a job. And protocols for when the simple case gets complicated." },
+
+    { "type": "summary", "heading": "Module 3 — Key Concepts", "items": ["Restoring equipment has its own seven-step sequence — check for personnel before removing any locks", "Group lockout: one person, one lock still applies — the lockbox method scales the principle", "Shift changes: new lock ON before old lock OFF — the overlap eliminates the gap", "Scope exclusions: cord-and-plug, minor servicing, and testing/positioning are narrow, fenced exceptions — not shortcuts", "Emergency lock removal: verify absence, attempt contact, notify before return — only ever under the employer's documented procedure", "Three roles: Authorized, Affected, Other. \"Qualified person\" is a real OSHA term, but it's an electrical-safety term (1910.399), not a fourth LOTO role", "The paperwork is evidence that the system worked and everyone goes home safe"] }
   ],
 
   "quiz": [
     {
-      "question": "In group lockout situations with multiple workers, how many locks should be applied?",
-      "options": [
-        "One lock controlled by the supervisor",
-        "Two locks — one for electrical, one for mechanical",
-        "One lock per person working on the equipment",
-        "The minimum number required to secure all energy sources"
-      ],
-      "correct": 2
-    },
-    {
-      "question": "What is the lockbox method used for?",
-      "options": [
-        "Storing extra padlocks for future use",
-        "When multiple workers need lockout but only one lock fits the disconnect",
-        "Emergency storage of critical equipment keys",
-        "Group lockout situations with more than 5 workers"
-      ],
+      "question": "During a shift change on a machine that's under lockout, the correct procedure is:",
+      "options": ["The outgoing crew removes their locks, then the incoming crew applies theirs", "The incoming crew applies their locks while the outgoing crew's locks are still in place, then the outgoing crew removes theirs", "The outgoing crew leaves their locks for the incoming crew to use", "A supervisor holds a master lock during the transition"],
       "correct": 1
     },
     {
-      "question": "During shift change, when should the incoming crew apply their locks?",
-      "options": [
-        "After the outgoing crew removes all their locks",
-        "Before the outgoing crew removes their locks (overlap protection)",
-        "Only if work will continue into the next shift",
-        "At the supervisor's discretion"
-      ],
-      "correct": 1
+      "question": "A worker's lock is on a machine, but they've left the facility without removing it. The correct response is:",
+      "options": ["Cut the lock immediately — production is delayed", "Leave the lock in place indefinitely until the worker returns", "Verify the worker is absent, attempt to contact them, remove the lock following emergency procedures, and ensure the worker is notified before returning to work", "Have another authorized employee remove the lock since they have the same training"],
+      "correct": 2
     },
     {
-      "question": "What step comes immediately before removing locks during equipment restoration?",
-      "options": [
-        "Clean up the work area",
-        "Replace all machine guards",
-        "Check for personnel — verify all workers are clear",
-        "Re-energize the equipment"
-      ],
+      "question": "A machine has room for only one lock on its energy isolation point, but four workers need to service it. The correct approach is:",
+      "options": ["The team lead places the single lock and holds the key for the group", "Workers take turns — one works while the others wait, each applying their lock for their turn", "The coordinator locks the machine, places the key in a lockbox, and each worker places their own lock on the lockbox", "One lock is sufficient as long as everyone agrees not to remove it"],
       "correct": 2
+    },
+    {
+      "question": "An operator's production line is shut down because maintenance is performing lockout/tagout on a connected machine. The operator is classified as:",
+      "options": ["An authorized employee, because they operate the equipment", "An affected employee, whose primary responsibility is to never attempt to restart locked-out equipment", "A qualified person, since this standard uses that term for anyone experienced with the equipment", "An other employee, because they aren't involved in the maintenance"],
+      "correct": 1,
+      "source": { "citation": "29 CFR 1910.399, \"Qualified person\"", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-S/subject-group-ECFR314553c63ae81f4/section-1910.399", "anchor": "Qualified person.   One who has received training in and has demonstrated skills and knowledge in the construction and operation of electric equipment and installations and the hazards involved." }
     }
   ]
 }

--- a/courses/loto/builds/module-03/index.html
+++ b/courses/loto/builds/module-03/index.html
@@ -638,27 +638,6 @@ html, body {
   min-width: 8rem;
 }
 
-/* Course Complete styles */
-.course-complete {
-  padding: 3vh;
-  background: var(--charcoal);
-  border-radius: 8px;
-  border: 2px solid var(--success-green);
-  margin: 3vh 0;
-}
-.course-complete h3 {
-  font-family: var(--font-display);
-  font-size: clamp(1.4rem, 2.8vw, 2rem);
-  color: var(--success-green);
-  margin-bottom: 2vh;
-}
-.course-complete p {
-  font-size: clamp(0.9rem, 1.6vw, 1.2rem);
-  line-height: 1.5;
-  color: var(--steel-dim);
-  margin-bottom: 1.5vh;
-}
-
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .slide {
@@ -697,7 +676,7 @@ html, body {
 
 /* Text shadow for body text over dark backgrounds - enhanced */
 .slide-keypoint .body,
-.slide-reveal .body, 
+.slide-reveal .body,
 .slide-concept .body,
 .slide-scene p,
 .slide-list .item-text,
@@ -705,6 +684,46 @@ html, body {
   text-shadow: 0 2px 12px rgba(0,0,0,0.8), 0 1px 3px rgba(0,0,0,0.9);
 }
 
+/* --- Citation chip (Reviewer mode) --- */
+.citation-chip {
+  position: absolute;
+  right: 2vw;
+  bottom: 1.5vh;
+  z-index: 3;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  font-family: var(--font-ui);
+  font-size: 0.72rem;
+  letter-spacing: 0.03em;
+  color: var(--steel-dim);
+  background: rgba(42,42,42,0.72);
+  border: 1px solid var(--steel-blue);
+  border-radius: 4px;
+  padding: 0.4em 0.7em;
+  text-decoration: none;
+  backdrop-filter: blur(3px);
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+.citation-chip:hover {
+  color: var(--safety-yellow);
+  border-color: var(--safety-yellow);
+}
+.citation-chip-icon {
+  opacity: 0.8;
+}
+
+/* --- Learner/Reviewer toggle --- */
+.bottom-bar-left {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+.mode-toggle-btn[aria-pressed="true"] {
+  background: var(--safety-yellow);
+  color: var(--bg-dark);
+  border-color: var(--safety-yellow);
+}
 
 
 
@@ -720,7 +739,10 @@ html, body {
   <div class="slide-container" id="slideContainer"></div>
 
   <div class="bottom-bar">
-    <a href="../index.html" class="nav-btn" style="margin-right: 2vw;">MENU</a>
+    <div class="bottom-bar-left">
+      <a href="../index.html" class="nav-btn">MENU</a>
+      <button class="nav-btn mode-toggle-btn" id="modeToggleBtn" onclick="toggleReviewerMode()" aria-pressed="false" title="Toggle citation view for review/compliance">Learner Mode</button>
+    </div>
     <div class="progress-section">
       <div class="progress-track">
         <div class="progress-fill" id="progressFill"></div>
@@ -737,94 +759,82 @@ html, body {
 <script>
 const MODULE = {
   "title": "When Simple Gets Complicated",
-  "moduleNumber": 3, 
+  "moduleNumber": 3,
   "partLabel": "Part Three — The Edge Cases",
   "passingScore": 75,
   "slides": [
-    { "type": "title", "moduleLabel": "Module 3", "heading": "When Simple\nGets Complicated", "subtitle": "Part Three — The Edge Cases", "brand": "SOPs Nobody Reads" },
-    { "type": "scene", "label": "Cold Open", "text": "Shift change. The outgoing crew walks toward the exit. One of them pulls a lock off a disconnect on their way out. Casual. Done for the day.", "image": "img/s01-shift-change.jpg" },
-    { "type": "scene", "label": "Scene", "text": "The disconnect has no lock now. The incoming crew is still in the break room getting briefed. For the next four minutes, this machine is unprotected.", "image": "img/s02-gap-in-protection.jpg" },
-    { "type": "reveal", "kicker": "The Gap", "heading": "Four minutes.\nThat's the gap between\none crew's safety and the next.", "body": "And in that gap, anyone could start this machine. Shift change creates vulnerability unless managed properly.", "image": "img/s03-four-minutes.jpg" },
-    { "type": "keypoint", "kicker": "Restoring Equipment", "heading": "Seven steps to\nbring it back safely", "body": "You've locked the machine out. You've done the work. Now it's time to restore the equipment. This has its own sequence, and it matters as much as the lockout itself.", "image": "img/s04-seven-steps.jpg" },
-    { "type": "list", "label": "Restoration Steps", "heading": "In this order. Every time.", "items": [
-      { "num": "1.", "text": "<strong>Inspect:</strong> Work is finished, all tools accounted for" },
-      { "num": "2.", "text": "<strong>Clean up:</strong> Parts, rags, work aids back where they belong" },
-      { "num": "3.", "text": "<strong>Replace guards:</strong> Every guard back before machine starts" },
-      { "num": "4.", "text": "<strong>Check controls:</strong> Everything in neutral or safest position" },
-      { "num": "5.", "text": "<strong>Check for personnel:</strong> All workers verified clear and notified" },
-      { "num": "6.", "text": "<strong>Remove your lock:</strong> Only your lock. Not someone else's." },
-      { "num": "7.", "text": "<strong>Re-energize:</strong> Follow manufacturer's startup procedures" }
-    ], "image": "img/s05-restoration-checklist.jpg" },
-    { "type": "concept", "label": "Check for Personnel", "boxText": "This is not a glance. This is a headcount.", "body": "If three people were working on this machine, three people must be verified clear before any lock comes off. Every person who was working must be accounted for and notified.", "image": "img/s06-headcount.jpg" },
-    { "type": "keypoint", "kicker": "Group Lockout", "heading": "Multiple workers,\nmultiple locks", "body": "When multiple workers need to service the same equipment, each one applies their own lock. The principle scales: one person, one lock. The machine cannot restart until the last lock is off.", "image": "img/s07-multiple-locks.jpg" },
-    { "type": "concept", "label": "Group Coordinator", "boxText": "Someone needs to be in charge. One authorized employee manages the overall lockout.", "body": "They don't replace individual locks. They organize the process, review procedures with everyone, and coordinate the work.", "image": "img/s08-coordinator.jpg" },
-    { "type": "keypoint", "kicker": "Lockbox Method", "heading": "What if there's only\nroom for one lock?", "body": "One lock goes on the disconnect. The key to that lock goes inside a lockbox. Each worker puts their own lock on the lockbox. The machine can't start until every worker removes their lock from the box.", "image": "img/s09-lockbox-method.jpg" },
-    { "type": "keypoint", "kicker": "Shift Change Protocol", "heading": "Continuous protection\nacross shift changes", "body": "The incoming crew applies their locks before the outgoing crew removes theirs. Overlap protection. The machine is never unprotected, not even for minutes.", "image": "img/s10-shift-overlap.jpg" },
-    { "type": "keypoint", "kicker": "Emergency Lock Removal", "heading": "When someone leaves\ntheir lock behind", "body": "This requires special authorization. The absent employee must be contacted and verified. Management approval required. All affected personnel notified. This is not a casual decision.", "image": "img/s11-emergency-removal.jpg" },
-    { "type": "concept", "label": "Roles and Responsibility", "boxText": "Authorized employee: Can apply and remove locks, coordinate group lockout. Affected employee: Notified of lockout, must stay clear.", "body": "Each role has specific responsibilities. Know which role you're in for each lockout situation. Authority matters. Clear communication matters.", "image": "img/s12-roles.jpg" },
-    { "type": "keypoint", "kicker": "The Paperwork Reframe", "heading": "Documentation isn't\nbureaucracy", "body": "It's memory. Who's working where. What energy sources are controlled. When the work started. When it ended. When someone gets hurt, this documentation explains what went right and what went wrong.", "image": "img/s13-documentation.jpg" },
-    { "type": "reveal", "kicker": "The Complete Picture", "heading": "LOTO isn't just\na six-step procedure", "body": "It's a comprehensive system. Individual lockout. Group lockout. Shift change protocols. Emergency procedures. Documentation. Each element protects against specific failure modes.", "image": "img/s14-complete-system.jpg" },
-    { "type": "keypoint", "kicker": "Course Complete", "heading": "You now understand\nthe energy you don't see", "body": "Five types of hazardous energy. Six steps to control them. Protocols for complex situations. The tools to protect yourself and your coworkers. Two minutes and a padlock. That's all it takes.", "image": "img/s15-course-complete.jpg" },
-    { "type": "summary", "heading": "LOTO Course — Key Concepts", "items": [
-      "LOTO is a comprehensive system, not just a procedure",
-      "Group lockout scales the one-person-one-lock principle",
-      "Lockbox method handles single-lock situations", 
-      "Shift change requires overlap protection",
-      "Emergency lock removal needs special authorization",
-      "Documentation provides memory and accountability",
-      "Everyone goes home safe — every shift, every day"
-    ] }
+    {"type": "title", "moduleLabel": "Module 3", "heading": "When Simple\nGets Complicated", "subtitle": "Part Three — The Edge Cases", "brand": "SOPs Nobody Reads"},
+    {"type": "scene", "label": "Cold Open", "text": "Shift change. A factory floor, afternoon bleeding into evening. The outgoing crew pulls their lock and heads for the exit.", "image": "img/s01-shift-change.jpg"},
+    {"type": "concept", "label": "The Gap", "boxText": "For the next four minutes, this machine is unprotected.", "body": "The outgoing crew pulled their locks. The incoming crew hasn't applied theirs yet. In that gap, anyone could start this machine.", "image": "img/s02-gap-in-protection.jpg"},
+    {"type": "list", "label": "Before the Edge Cases", "heading": "Restoring Equipment — Seven Steps", "items": [{"num": "1.", "text": "<strong>Inspect.</strong> Make sure the work is actually finished."}, {"num": "2.", "text": "<strong>Clean up.</strong> Parts, rags, work aids back where they belong."}, {"num": "3.", "text": "<strong>Replace guards.</strong> Every guard goes back before startup."}, {"num": "4.", "text": "<strong>Check controls.</strong> Everything in neutral or its safest position."}, {"num": "5.", "text": "<strong>Check for personnel.</strong> A headcount, not a glance."}, {"num": "6.", "text": "<strong>Remove your lock.</strong> Only yours."}, {"num": "7.", "text": "<strong>Re-energize.</strong> Follow the documented startup sequence."}]},
+    {"type": "keypoint", "kicker": "The Critical Ones", "heading": "Check for personnel.\nRemove your lock.\nRe-energize.", "body": "This is a headcount, not a glance. Your lock — not someone else's. Follow the manufacturer's startup sequence, not the reverse of shutdown.", "image": "img/s06-headcount.jpg"},
+    {"type": "concept", "label": "Group Lockout", "boxText": "One worker, one machine, one lock — the principle scales.", "body": "A group coordinator manages the process without replacing individual locks. Each worker applies their own. The machine can't restart until the last lock is off.", "image": "img/s07-multiple-locks.jpg"},
+    {"type": "keypoint", "kicker": "The Lockbox Method", "heading": "One lock on the machine.\nThe key goes in a box.\nEveryone locks the box.", "body": "The machine can't restart until the lockbox opens. The lockbox can't open until every worker removes their lock. Same protection. Different geometry.", "image": "img/s09-lockbox-method.jpg"},
+    {"type": "reveal", "kicker": "The Solution", "heading": "New lock on.\nThen old lock off.", "body": "The incoming worker's lock goes on while the outgoing worker's lock is still there. At no point is the hasp empty. At no point is the machine unprotected.", "image": "img/s10-shift-overlap.jpg"},
+    {"type": "keypoint", "kicker": "Three Edge Cases", "heading": "Written into the standard,\nnot made up to save time.", "body": "Places where the standard draws its own boundaries. Learn them as boundaries, not shortcuts."},
+    {"type": "concept", "label": "Cord-and-Plug Equipment", "boxText": "Unplugged AND under your exclusive control — both, not one.", "body": "A bench grinder. A portable drill. If the plug stays in your hand, your pocket, your sight the whole time, this standard doesn't require lockout on it.", "source": {"citation": "29 CFR 1910.147(a)(2)(iii)(A)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(a)(2)(iii)(A)", "anchor": "Work on cord and plug connected electric equipment for which exposure to the hazards of unexpected energization or start up of the equipment is controlled by the unplugging of the equipment from the energy source and by the plug being under the exclusive control of the employee performing the servicing or maintenance."}},
+    {"type": "reveal", "kicker": "The Most Misused Exception", "heading": "Minor servicing —\nread the fence twice.", "body": "Normal production operations. Routine. Repetitive. Integral to production. Alternative measures providing effective protection. All of it. Every time.", "source": {"citation": "29 CFR 1910.147(a)(2)(ii), Note", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(a)(2)(ii)", "anchor": "Exception to paragraph (a)(2)(ii): Minor tool changes and adjustments, and other minor servicing activities, which take place during normal production operations, are not covered by this standard if they are routine, repetitive, and integral to the use of the equipment for production, provided that the work is performed using alternative measures which provide effective protection (See subpart O of this part)."}},
+    {"type": "keypoint", "kicker": "Not a Badge You Assume", "heading": "\"Clearing a jam\"\nis the classic misuse.", "body": "If your alternative measure isn't actually providing effective protection, you don't have an exception. You have an unprotected worker near a hazard."},
+    {"type": "concept", "label": "Testing / Positioning", "boxText": "An exact sequence, in order — not an ad-hoc override.", "body": "Clear tools and personnel. Remove LOTO devices. Energize, test or position. De-energize, reapply LOTO. Same discipline as the six steps.", "source": {"citation": "29 CFR 1910.147(f)(1)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(f)(1)", "anchor": "In situations in which lockout or tagout devices must be temporarily removed from the energy isolating device and the machine or equipment energized to test or position the machine, equipment or component thereof, the following sequence of actions shall be followed:"}},
+    {"type": "scene", "label": "Emergency Lock Removal", "text": "A disconnect with a single lock. Shift's over. The person whose lock this is? Gone. Not answering their phone.", "image": "img/s11-emergency-removal.jpg"},
+    {"type": "concept", "label": "Not a Coworker's Call", "boxText": "Only under the employer's direction, through a procedure documented in advance.", "body": "Nobody improvises this in the moment.", "source": {"citation": "29 CFR 1910.147(e)(3)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(e)(3)", "anchor": "Exception to paragraph (e)(3): When the authorized employee who applied the lockout or tagout device is not available to remove it, that device may be removed under the direction of the employer, provided that specific procedures and training for such removal have been developed, documented and incorporated into the employer's energy control program."}},
+    {"type": "list", "label": "The Documented Procedure", "heading": "Three Elements", "items": [{"num": "1.", "text": "<strong>Verify the employee is absent.</strong> Not in the building, not on break."}, {"num": "2.", "text": "<strong>Make reasonable efforts to contact them.</strong> Document the attempts."}, {"num": "3.", "text": "<strong>Inform them before they return.</strong> Before they approach any equipment."}]},
+    {"type": "reveal", "kicker": "Why Notification Matters", "heading": "The lock removal isn't\ncomplete until they know.", "body": "A worker returning to a machine they think is locked out, reaching in confident — that's the alternative this requirement prevents."},
+    {"type": "concept", "label": "Three Roles — 29 CFR 1910.147(b)", "boxText": "Authorized. Affected. Other.", "body": "Each role carries different responsibilities, different training, different obligations.", "source": {"citation": "29 CFR 1910.147(b)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(b)", "anchor": "Affected employee.   An employee whose job requires him/her to operate or use a machine or equipment on which servicing or maintenance is being performed under lockout or tagout, or whose job requires him/her to work in an area in which such servicing or maintenance is being performed. / Authorized employee.   A person who locks out or tags out machines or equipment in order to perform servicing or maintenance on that machine or equipment."}},
+    {"type": "keypoint", "kicker": "Authorized Employees", "heading": "They perform\nthe lockout.", "body": "Trained on every energy source, every isolation point. They apply the locks. They verify the isolation."},
+    {"type": "keypoint", "kicker": "Affected Employees", "heading": "Their work is affected —\nthey don't perform it.", "body": "An operator whose line is shut down for maintenance. Their job: never attempt to restart locked-out equipment. Ever."},
+    {"type": "concept", "label": "Other Employees", "boxText": "Basic awareness training.", "body": "Lockout exists. Locked-out equipment is off-limits. Attempting to start it can kill the person inside.", "source": {"citation": "29 CFR 1910.147(c)(7)(i)(A), (B), (C)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(c)(7)(i)(A)", "anchor": "(A) Each authorized employee shall receive training in the recognition of applicable hazardous energy sources, the type and magnitude of the energy available in the workplace, and the methods and means necessary for energy isolation and control. / (B) Each affected employee shall be instructed in the purpose and use of the energy control procedure. / (C) All other employees whose work operations are or may be in an area where energy control procedures may be utilized, shall be instructed about the procedure, and about the prohibition relating to attempts to restart or reenergize machines or equipment which are locked out or tagged out."}},
+    {"type": "reveal", "kicker": "Real Term, Wrong Standard", "heading": "\"Qualified person\"\nisn't a fourth role.", "body": "It's a real OSHA term — just not from this standard. It means trained to work on or near exposed energized electrical parts.", "source": {"citation": "29 CFR 1910.399, \"Qualified person\"", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-S/subject-group-ECFR314553c63ae81f4/section-1910.399", "anchor": "Qualified person.   One who has received training in and has demonstrated skills and knowledge in the construction and operation of electric equipment and installations and the hazards involved."}},
+    {"type": "keypoint", "kicker": "Different Standard, Different Question", "heading": "Not \"what's your job\nhere\" — \"are you trained\nfor live electrical work.\"", "body": "A qualified person might also be an authorized employee on a lockout. Those aren't mutually exclusive. But qualified person answers a different question."},
+    {"type": "concept", "label": "The Forms, Reframed", "boxText": "Not bureaucracy. Evidence.", "body": "The procedure form is the map. The training certification is proof you were taught this. The inspection certification is proof someone verified it."},
+    {"type": "keypoint", "kicker": "Outside Contractors", "heading": "An information exchange.\nNot a certificate.", "body": "The on-site and outside employer inform each other of their procedures. A conversation, not a document either side signs and files.", "source": {"citation": "29 CFR 1910.147(f)(2)(i)", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-J/section-1910.147#p-1910.147(f)(2)(i)", "anchor": "Whenever outside servicing personnel are to be engaged in activities covered by the scope and application of this standard, the on-site employer and the outside employer shall inform each other of their respective lockout or tagout procedures."}},
+    {"type": "reveal", "kicker": "The Thesis", "heading": "Every piece of paper\nexists because someone\nwas hurt by its absence.", "body": "The paperwork isn't bureaucracy. It's evidence that the system worked and everyone goes home safe."},
+    {"type": "scene", "label": "Back to Shift Change", "text": "The same factory floor. Shift change. But now the handoff is different."},
+    {"type": "scene", "label": "Scene", "text": "The incoming worker inside the machine. Working steadily. The lock visible in the background. Protection in place."},
+    {"type": "reveal", "kicker": "Same Shift Change", "heading": "The difference is\nthirty seconds\nand a padlock.", "body": "The procedure is simple. The edge cases are manageable. The paperwork has a purpose. The principle never changes — it just adapts.", "image": "img/s15-course-complete.jpg"},
+    {"type": "keypoint", "kicker": "The Course, In One Line", "heading": "Six sources.\nSix steps.\nThree roles.", "body": "Six named energy sources, each with its own stored-energy shadow. Six steps that turn off into safe. Three roles, each with a job. And protocols for when the simple case gets complicated."},
+    {"type": "summary", "heading": "Module 3 — Key Concepts", "items": ["Restoring equipment has its own seven-step sequence — check for personnel before removing any locks", "Group lockout: one person, one lock still applies — the lockbox method scales the principle", "Shift changes: new lock ON before old lock OFF — the overlap eliminates the gap", "Scope exclusions: cord-and-plug, minor servicing, and testing/positioning are narrow, fenced exceptions — not shortcuts", "Emergency lock removal: verify absence, attempt contact, notify before return — only ever under the employer's documented procedure", "Three roles: Authorized, Affected, Other. \"Qualified person\" is a real OSHA term, but it's an electrical-safety term (1910.399), not a fourth LOTO role", "The paperwork is evidence that the system worked and everyone goes home safe"]},
   ],
   "quiz": [
-    {
-      "question": "In group lockout situations with multiple workers, how many locks should be applied?",
-      "options": [
-        "One lock controlled by the supervisor",
-        "Two locks — one for electrical, one for mechanical",
-        "One lock per person working on the equipment",
-        "The minimum number required to secure all energy sources"
-      ],
-      "correct": 2
-    },
-    {
-      "question": "What is the lockbox method used for?",
-      "options": [
-        "Storing extra padlocks for future use",
-        "When multiple workers need lockout but only one lock fits the disconnect",
-        "Emergency storage of critical equipment keys",
-        "Group lockout situations with more than 5 workers"
-      ],
-      "correct": 1
-    },
-    {
-      "question": "During shift change, when should the incoming crew apply their locks?",
-      "options": [
-        "After the outgoing crew removes all their locks",
-        "Before the outgoing crew removes their locks (overlap protection)",
-        "Only if work will continue into the next shift",
-        "At the supervisor's discretion"
-      ],
-      "correct": 1
-    },
-    {
-      "question": "What step comes immediately before removing locks during equipment restoration?",
-      "options": [
-        "Clean up the work area",
-        "Replace all machine guards",
-        "Check for personnel — verify all workers are clear",
-        "Re-energize the equipment"
-      ],
-      "correct": 2
-    }
+    {"question": "During a shift change on a machine that's under lockout, the correct procedure is:", "options": ["The outgoing crew removes their locks, then the incoming crew applies theirs", "The incoming crew applies their locks while the outgoing crew's locks are still in place, then the outgoing crew removes theirs", "The outgoing crew leaves their locks for the incoming crew to use", "A supervisor holds a master lock during the transition"], "correct": 1},
+    {"question": "A worker's lock is on a machine, but they've left the facility without removing it. The correct response is:", "options": ["Cut the lock immediately — production is delayed", "Leave the lock in place indefinitely until the worker returns", "Verify the worker is absent, attempt to contact them, remove the lock following emergency procedures, and ensure the worker is notified before returning to work", "Have another authorized employee remove the lock since they have the same training"], "correct": 2},
+    {"question": "A machine has room for only one lock on its energy isolation point, but four workers need to service it. The correct approach is:", "options": ["The team lead places the single lock and holds the key for the group", "Workers take turns — one works while the others wait, each applying their lock for their turn", "The coordinator locks the machine, places the key in a lockbox, and each worker places their own lock on the lockbox", "One lock is sufficient as long as everyone agrees not to remove it"], "correct": 2},
+    {"question": "An operator's production line is shut down because maintenance is performing lockout/tagout on a connected machine. The operator is classified as:", "options": ["An authorized employee, because they operate the equipment", "An affected employee, whose primary responsibility is to never attempt to restart locked-out equipment", "A qualified person, since this standard uses that term for anyone experienced with the equipment", "An other employee, because they aren't involved in the maintenance"], "correct": 1, "source": {"citation": "29 CFR 1910.399, \"Qualified person\"", "url": "https://www.ecfr.gov/current/title-29/subtitle-B/chapter-XVII/part-1910/subpart-S/subject-group-ECFR314553c63ae81f4/section-1910.399", "anchor": "Qualified person.   One who has received training in and has demonstrated skills and knowledge in the construction and operation of electric equipment and installations and the hazards involved."}}
   ]
 };
 
-// Player JavaScript (modified for course completion)
+// Player JavaScript (same as AI onboarding, no modifications needed)
 let currentSlide = 0;
 let quizAnswers = [];
 let quizMode = false;
 let currentQuizQuestion = 0;
 let isAnswered = false;
+
+// Reviewer mode: view state only, in-memory for this session. NOT persisted
+// (no localStorage) — this player gets packaged for SCORM/LMS delivery, and
+// LMS iframe storage-partitioning makes localStorage unreliable inside an SCO.
+// Never touches SCORM/LMS calls or completion/score tracking.
+let reviewerMode = false;
+
+function toggleReviewerMode() {
+  reviewerMode = !reviewerMode;
+  const btn = document.getElementById('modeToggleBtn');
+  btn.textContent = reviewerMode ? 'Reviewer Mode' : 'Learner Mode';
+  btn.setAttribute('aria-pressed', String(reviewerMode));
+  renderSlide();
+}
+
+// Returns citation chip HTML, or '' if reviewer mode is off or the source
+// is missing/incomplete. Fail-safe: never renders a partial or fabricated
+// citation — citation and url are both required.
+function renderCitation(source) {
+  if (!reviewerMode || !source || !source.citation || !source.url) return '';
+  return `
+    <a class="citation-chip" href="${source.url}" target="_blank" rel="noopener">
+      <span class="citation-chip-icon">&sect;</span>${source.citation}
+    </a>
+  `;
+}
 
 function initPlayer() {
   renderSlide();
@@ -958,9 +968,11 @@ function renderSlide() {
       `;
       break;
   }
-  
+
+  html += renderCitation(slide.source);
+
   container.innerHTML = html;
-  
+
   // Activate the slide
   setTimeout(() => {
     const slideEl = container.querySelector('.slide');
@@ -1009,7 +1021,7 @@ function renderQuiz() {
     `;
   }
   
-  const html = `
+  let html = `
     <div class="slide slide-quiz active">
       <div class="quiz-container">
         <h2>Question ${currentQuizQuestion + 1}</h2>
@@ -1023,7 +1035,9 @@ function renderQuiz() {
       </div>
     </div>
   `;
-  
+
+  html += renderCitation(question.source);
+
   container.innerHTML = html;
 }
 
@@ -1038,10 +1052,10 @@ function selectAnswer(answerIndex) {
 
 function getQuizFeedback(questionIndex) {
   const feedbacks = [
-    "In group lockout, each person working on the equipment applies their own lock for individual protection.",
-    "The lockbox method is used when multiple workers need lockout but only one lock fits the disconnect point.",
-    "Overlap protection means incoming crew applies locks before outgoing crew removes theirs, ensuring continuous protection.",
-    "Checking for personnel (headcount) is the critical step immediately before removing any locks during restoration."
+    "New lock on before old lock off. That overlap means the hasp is never empty and the machine is never unprotected during the handoff.",
+    "This only happens under the employer's documented procedure — verify absence, attempt contact, and make sure the worker knows before they come back. Not a coworker's judgment call in the moment.",
+    "The lockbox method scales one person, one lock to a group: one lock on the machine, the key inside a box, everyone locks the box. Same protection, different geometry.",
+    "The operator didn't perform the lockout, but their work is affected by it — that makes them an affected employee, whose job is to never attempt to restart locked-out equipment. Note: \"qualified person\" is a real OSHA term, but it's from the electrical safety standards (1910.399), not this standard — it isn't a role this standard defines, and being \"experienced with the equipment\" isn't what the term means even where it does apply."
   ];
   return feedbacks[questionIndex] || '';
 }
@@ -1064,21 +1078,12 @@ function renderResults() {
           ${correctAnswers} of ${totalQuestions} questions correct<br>
           ${passed ? 'You passed! Well done.' : `You need ${MODULE.passingScore}% to pass. Please review the material and try again.`}
         </div>
-        
-        ${passed ? `
-        <div class="course-complete">
-          <h3>🎉 LOTO Course Complete!</h3>
-          <p>You have completed all three modules of the Lockout/Tagout course. You now understand how to control hazardous energy and protect yourself and your coworkers.</p>
-          <p><strong>Remember:</strong> Two minutes and a padlock. That's all it takes to ensure everyone goes home safe.</p>
-        </div>
-        ` : ''}
-        
         <div class="results-actions">
           ${!passed ? `<button class="nav-btn" onclick="restartQuiz()">Try Again</button>` : ''}
-          <a href="../index.html" class="nav-btn">Course Menu</a>
+          <a href="../index.html" class="nav-btn">Course Complete &#8594;</a>
         </div>
         <p style="margin-top: 3vh; font-size: 0.9rem; color: var(--steel-dim);">
-          ${passed ? 'Course Complete — All 3 modules finished successfully!' : 'Module 3 of 3 — Review the material and retake the quiz to complete the course.'}
+          Module 3 of 3 &mdash; Course complete. Six sources, six steps, three roles.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Phase 4b of the LOTO Pass-4 brief (Tasks 1-5). Regenerates `module-02.json`/`module-03.json` and both players wholesale from the final, source-faithful scripts — neither old build survives, both carried independent drift.

**base=main, head=claude/loto-m2-m3-build-regen-20260714.** Branched fresh off main, no stacking.

## What changed
- **Module 2:** 23 slides, 4 quiz, 2 source citations — (c)(2)(i)/(c)(2)(ii) tagout structure, (d)(5)(ii) reaccumulation.
- **Module 3:** 31 slides, 4 quiz, 9 source citations — cord-and-plug, minor-servicing, testing/positioning, emergency removal, three roles, the qualified-person reframe, contractor info exchange. (8 from script `source_ref`s + 1 added to Quiz Q4 per Task 4, reusing the already-verified 1910.399 citation.)
- **Citation toggle ported to both players**, byte-identical to Module 1's implementation — confirmed via `diff`: only `<title>`, the `MODULE` data, `getQuizFeedback` strings, and the results-slide next-action/module-count text differ across all three players. Same `renderCitation()` fail-safe gate, same Learner/Reviewer button, same in-memory-only state.
- **Task 4:** Quiz Q4's "qualified person" distractor now carries feedback explaining *why* it's wrong (a real OSHA term, but from 1910.399's electrical-safety standards, not a LOTO role) instead of silently reinforcing the exact misconception this phase corrected. Verified live in a browser — see below.
- **Confirmed and removed**: module-03's old build had a fabricated "Five types of hazardous energy" course-complete slide that was never in any script. Gone — the new build has nothing to regenerate it from.

## Image manifests — mapped, not generated
`module-02-image-manifest.md`, `module-03-image-manifest.md`. Every reuse candidate was opened and visually checked, not filename-matched. This caught real problems again:
- **M2:** two more garbled-text images ("FULD DLOWK" lock tag, "LOCKLLOW TAG OUT" tag) — same defect class as Module 1's Phase 2 findings.
- **M3:** a clipboard reading "LOCKLOUT TAG..." (garbled), and — exactly as the brief predicted — **the old roles diagram literally shows four people**, now wrong under the three-role reframe. Flagged as the top-priority NEW asset.

7 images reused in M2, 8 in M3 (15 total, all visually verified clean). Both manifests give priority ordering for the next image pass. No images generated.

## Verification
- [x] `grep` sweep across both JSON + both players: zero hits for five-type taxonomy, four-role framing, "3000", or the fabricated recap line
- [x] All 9 unique source anchors re-verified against their frozen file (1910.147 or 1910.399) after regeneration
- [x] JSON parses (Python); inline player `MODULE` parses as valid JS (Node) — slide/quiz/source counts match **exactly** between JSON and player, both modules
- [x] CSS/JS shell diff-verified byte-identical to Module 1 except the 5 intended per-module differences
- [x] **Live Playwright run, both modules:** Learner mode → 0 citation chips; Reviewer mode → chips appear on exactly the expected slides (M2: 13, 15; M3: 10, 11, 13, 15, 18, 21, 22, 25) with correct `href`s; full slide→quiz→results navigation; **zero console errors**
- [x] Q4's "qualified person" answer path specifically exercised — confirmed the feedback text and its citation chip render correctly

**Same-story confirmation:**
- *Module 2* — the script teaches six steps with the corrected tagout-structure and stored-energy-reaccumulation fixes; the JSON decomposes that into 23 slides + 4 quiz items carrying the same two citations; the player's inline copy is identical in content to the JSON (verified above), CSS/JS shell untouched.
- *Module 3* — the script teaches the restore sequence, group lockout, shift overlap, the three new scope-exclusion boundaries, emergency removal, the three-role reframe (with the 1910.399 cross-standard citation), and paperwork-as-evidence; the JSON carries all of that into 31 slides + 4 quiz items with all 9 citations; the player matches exactly, with the qualified-person quiz distractor now teaching instead of silently reinforcing the error.

## Not done here (by design)
- No images generated — Task 5 was explicitly "map, don't generate."
- No further content changes — this phase is structural/visual decomposition of already-settled scripts.
- No self-certification — the Phase 5 re-audit still stands, by a fresh instance, across all three modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)