### PR TITLE
Add governance docs: Build Methodology, Course-Audit Skill, Positioning Doctrine

### DIFF
--- a/docs/standards/BUILD-METHODOLOGY.md
+++ b/docs/standards/BUILD-METHODOLOGY.md
@@ -1,0 +1,116 @@
+# The Build Methodology
+
+Operational companion to the Durability Standard.
+Version 0.1 — 2026-07-16
+
+## Preamble: What This Document Is
+
+The Durability Standard is the constitution — it defines *what* a durable course is (the atom schema, source acceptance, the four passes, the acceptance test) and *why* each rule exists. This document is the operational layer: *how* a build is actually run, end to end, and the process discipline that keeps a build from failing in the ways ours failed before this methodology existed.
+
+The Standard tells you the invariant. This tells you the workflow that holds it — and, as importantly, catalogs the specific ways that workflow leaks, because every leak below was paid for in a real build.
+
+The one-line north star, from which everything else follows:
+
+> **Render from source. Never create source.**
+
+A course is a *rendering* of an authoritative document into a form a learner can absorb. It is not new source material. Every failure this methodology guards against is, at root, the system creating source — asserting something the frozen document does not say — instead of rendering what it does. The question is never "is this true?" but "does the frozen source say this, and can I point to where?"
+
+## §M1 — The Workflow
+
+A build runs in this fixed order. Later stages render *from* earlier ones; an earlier stage is never edited to match a later one. When an upstream artifact changes, everything downstream is **regenerated**, not hand-patched.
+
+1. **Freeze the source** (§M2). Before a single word of content is written, the authoritative source is fetched, verified current, provenance-stamped, checksummed, and committed. No content work begins against an unfrozen source, and nothing is ever written from memory of a regulation.
+2. **Render the script from the frozen source** (§M3). Prose is written *from* the frozen text. Every claim that asserts a fact carries a `source_ref` pointing to the exact paragraph, verified verbatim.
+3. **Decompose the script into the build (JSON).** The script is sliced into the module data structure (the decomposition stage — the LXD skill). This is a *structural* transformation, not a content one: it adds, removes, and rewords nothing. Every `source_ref` carries through.
+4. **Render the player from the build.** The JSON becomes the delivered HTML player (the presentation stage — the aesthetic-design skill), including the citation feature that renders each `source_ref` back to the learner or reviewer.
+5. **Images — last, and optional.** Visuals are supporting cast. A slide with no image and a correct, cited claim outranks a beautiful slide that is subtly wrong. Images are generated only after the content is source-final; labeled diagrams are built *in the player*, not generated, because generators mangle text.
+6. **Audit, fix, re-audit — to a clean verdict** (§M4).
+7. **Ship gate.** Nothing reaches a prospect until an independent audit returns a clean verdict *and* every decision record is signed.
+
+The ordering is load-bearing. A build layer drifts from its script the moment a human or model edits it directly; the only safe edit to a downstream layer is to regenerate it from a corrected upstream one.
+
+## §M2 — Source Freeze (the First Gate)
+
+The founding failure of the original course was that it was built from a "sample written program" — a derivative that paraphrases the regulation — instead of the regulation itself. The freeze exists to make that class of error impossible.
+
+**Find the authoritative source, not a PDF.** A PDF is a snapshot with no way to prove it reflects current law, and most documents that surface are derivatives (training modules, sample programs, vendor explainers, university handouts) that paraphrase rather than reproduce. The date on a derivative is irrelevant; it is the wrong *kind* of document at any date.
+
+The hierarchy of authority for U.S. federal regulation:
+
+- **eCFR (ecfr.gov)** — the continuously-updated official codification. It carries a live "up to date as of" stamp, a point-in-time timeline showing when the content last changed, and the Federal Register amendment trail. This is the primary frozen source. Currency is *proven*, not assumed: read the "up to date as of" date, the timeline, and the amendment citations.
+- **govinfo.gov Published Edition** — the official annual print CFR. Citable, but lags; a backstop.
+- **The agency's own page (e.g. osha.gov)** — a reproduction, useful as an independent cross-check, not the code of record.
+- **Rejected as source-of-truth:** any derivative — training modules, sample programs, explainers. Fine as commentary, never as the frozen source.
+
+**Freeze cross-referenced standards too.** When the source borrows a term defined in another regulation, that regulation is frozen as a second source. (A term can *describe* a real thing while being *filed under the wrong standard*: the course wrongly taught "qualified person" as a lockout role when it is defined in the electrical standards — the reframe required freezing 1910.399.)
+
+**Provenance and integrity, per Durability Standard §2.2.** Each frozen file is committed as pure source text — no added headers, so its checksum stays stable — beside a separate provenance record holding: citation, source URL, the "up to date as of" date, last-amended date, fetch timestamp, and a SHA-256 of the file. Cross-check the frozen text against a second independent rendering (e.g. the agency page) on the load-bearing passages. An identical typo across two independent fetches is positive proof they render the same underlying text.
+
+**Fetch to disk, never through the model.** The bytes of a large source are pulled straight to disk (curl / API), not fetched-then-written by the model — routing source text through the model's own output is both a fidelity risk and, past a few kilobytes, a hard failure. This is a tooling constraint with a fidelity payoff: the source lands unmediated.
+
+## §M3 — Rendering Discipline
+
+**Every factual claim carries a `source_ref`.** The reference has three parts: the citation string (e.g. `29 CFR 1910.147(d)(5)(ii)`), a deep link to the exact paragraph, and a *verbatim* anchor — text quoted exactly from the frozen file. Before any claim ships, its anchor is confirmed to grep-match the frozen file. A claim that cannot be anchored does not ship.
+
+**Anchors are verbatim, one span each.** An anchor is exact quoted source text — never a paraphrase, and never a paraphrase wearing quotation marks. Where a claim rests on two provisions, the anchor holds two separately-quoted spans, explicitly marked as separate, never stitched into one false continuous quote. (Anchor grammar — whitespace, embedded commentary, composite anchors — is a recurring drift point. The precise anchor schema belongs in the Durability Standard's atom schema; per-artifact flagging has repeatedly failed to converge it.)
+
+**Regenerate downstream; never hand-patch the build.** A build layer accumulates its own drift independent of the script — in this project a build once carried a different, also-wrong energy taxonomy and a fabricated ending the script never contained. The only safe correction to a build or player is to fix the script and regenerate. Hand-patching a downstream layer treats a symptom and hides the divergence.
+
+**The citation feature is the product, not decoration.** The player renders each `source_ref` as a citation chip behind a Learner / Reviewer toggle (default Learner: chips hidden; Reviewer: chips shown, each linking to the regulation). This makes "rendered from source" *checkable* by a buyer in the room. The hard rule: a rendered citation must verify against the frozen file — a wrong citation is worse than none, especially in a compliance sale. The roadmap extends the loop: `source → course → cited back to source` becomes `company SOP → course → cited back to the SOP`, closing a loop no generic course can offer.
+
+## §M4 — The Audit Loop
+
+**The audit is adversarial and independent (Durability Standard §9).** An auditor's job is to *find* what is wrong, not to confirm it is right. The auditor is a fresh instance that did not write the course or the fixes; the fixer never self-certifies. The detailed procedure — six passes and two guards — lives in the course-audit skill. This section states only the loop and the two disciplines that make it work.
+
+**Pre-audit self-check: clear the whole surface before handoff.** This is the single change that turned the loop from a grind into convergence. For the first several rounds the independent audit was doing double duty — it was both the *gate* and the *first discovery* of our own misses — so each round surfaced one blocker at a time. The fix: the fixer/reviewer runs the full audit themselves (all passes, all guards, whole surface, claim level) *before* handing off, so the independent audit *confirms* a cleared course rather than discovering an uncleared one. When the self-check is genuine, the independent audit comes back clean on its first full pass.
+
+**The loop:** self-check → independent audit → fix from source → regenerate → fresh re-audit → repeat until a clean verdict. Then, and only then, the ship gate.
+
+**A clean verdict is the exit, and it is real.** Rounds of blockers followed by a clean verdict — here, two re-audit rounds with blockers and a clean third — is convergence, not luck, *provided each round the checks got wider, not just the fixes*. If a round returns a genuinely new-class blocker on a surface the self-check claimed to clear, that is the signal that the *pipeline itself* is suspect, and the response is to redesign it, not patch again.
+
+## §M5 — Process Discipline (Failure-Mode Guards)
+
+Each rule below prevents a specific failure this project actually suffered. They are not style preferences; they are scar tissue.
+
+**Branch off `main`; base every PR on `main`; never stack.** A stacked PR — one based on another PR's branch — produced a repeated merge failure: the child PR was first closed without merging, then on a second attempt merged *into its parent's branch* while GitHub reported "successfully merged and closed," so its content never reached `main`. When work depends on unmerged work, merge the dependency and branch fresh. Do not stack.
+
+**Gate on topology before building or auditing on a merge.** A PR reported "merged" may not have reached `main` (wrong base, unmerged child, replication lag). Before treating content as landed — especially before pointing an audit at it — confirm with an ancestor check (`git merge-base --is-ancestor <branch> origin/main`) *and* by reading the content on live `main`, not a local clone. (A stale local clone once misrepresented `main`'s state, masking which fixes had actually landed — which is why the check reads live `main`, not a cached copy.) An audit run against a stale premise is worse than no audit.
+
+**Make every check as wide as the invariant.** The invariant is not "does this claim match the source" but "does the whole deliverable, in order, across every file and every layer, still obey the source." Each narrowing of a check was a leak:
+
+- *Whole-surface scope.* Sweeps scoped to `scripts/` + `builds/` let a phantom source line survive in the README through three audits — the first file a buyer opens. Sweep the entire deliverable: every file a buyer or learner can open, including the README, decision records, manifests, and prompt files. Records *of* the errors (audit docs, session logs) are excluded.
+- *Claim level, not section level.* A completeness check at section-header granularity self-reports clean while individual claims are silently dropped. Verify every taught claim — cited or not — survives into every layer.
+- *Both directions.* Check for content in the build absent from the script (fabrication) *and* content in the script absent from the build (loss). This project's regressions were losses.
+- *Order, not just presence.* Where the source mandates a sequence, a step that is present but mis-ordered is still a violation. (The final blocker was a correct, sourced notification placed one step too late.)
+- *All layers, including non-obvious ones.* Any string a learner can read is a content layer — including hardcoded feedback strings in the player's JavaScript, which went unaudited for several rounds.
+
+**Run a regression check every fix.** A fix can delete or displace previously-correct content. Diff the content a prior audit verified as present against the current build; report anything now missing. Two of this project's blockers came from fixes going wrong: one deleted a required notification step, and the very fix that later restored it placed it in the wrong order.
+
+**A human signs decisions.** Where the source conflicts with itself, or a scope boundary must be drawn, the resolution is recorded and *signed by the accountable person* (Durability Standard §5 / §7). A model may apply a resolution, but the record must show a human ruled — the repo must never represent a package as decision-complete while a decision record still reads "pending."
+
+## §M6 — Named Tells
+
+These heuristics recur across audits; the full catalog and their use live in the course-audit skill. In brief:
+
+- **Memory-blend error** — the founding failure class: a true-sounding claim given false authority ("OSHA recognizes five types," "four employee roles," "master keys are prohibited"). The idea may be reasonable; the attribution to the source is invented.
+- **Reframe-is-a-finding** — if you catch yourself mentally rewording a claim to make it defensible, that is a finding, not a fix.
+- **Partial-check miss** — verifying one claim in a section does not clear the section; the four-roles error hid beside a sibling claim that had "checked out."
+- **Build-guilty-until-proven** — never assume a build matches its script.
+- **Mis-attribution** — a claim can describe a real thing while filing it under the wrong standard.
+- **Numbers guilty until grep-proven** — every figure is verified against the source or removed.
+- **Shared-typo proof** — an identical typo across two independent fetches confirms they render the same underlying text.
+
+## §M7 — Document Map and Roadmap
+
+This methodology is one of a small set:
+
+- **The Durability Standard** — the constitution: atom schema, source acceptance, the four passes, the acceptance test, conflict log, signers. The *why* and *what*.
+- **This Build Methodology** — the operational *how*: the workflow, the source-freeze protocol, rendering discipline, the audit loop, and the process guards.
+- **The course-audit skill** — the executable audit: the six passes, the two guards, and the named tells in full.
+- **The positioning doctrine** — the honest-claim principle: a course *teaches the standard, accurately and cited*; it does not "ensure compliance," because compliance is workplace-specific and belongs to the employer. Marketing claims obey the same "render, don't create" rule as course claims.
+
+**Roadmap.** The citation loop closes further when a client's own SOPs become a frozen source, so the delivered course cites back to the company's own documents — the full loop.
+
+---
+
+*Version 0.1 — 2026-07-16. Captured from the LOTO build, which reached a clean audit verdict on its third re-audit round. Provisional: to be revised as later builds test these rules, and as the anchor-grammar schema and the topological merge gate are absorbed into the Durability Standard and the tooling, respectively.*

--- a/docs/standards/POSITIONING.md
+++ b/docs/standards/POSITIONING.md
@@ -1,0 +1,46 @@
+# The Positioning Doctrine
+
+How the product is described and sold. Companion to the Durability Standard and the Build Methodology.
+Version 1.0 — 2026-07-16
+
+## Preamble
+
+Marketing claims obey the same rule as course claims: **render from source, never create source.** The positioning is downstream of the product's integrity — you cannot credibly sell "built from the regulation, every claim cited" using a headline the regulation does not support. The most dangerous claim a course company can make is the marketing-layer instance of a memory-blend error: asserting in the pitch something the source will not back. It is the same disease as a wrong claim in a course, and it has the same cure.
+
+This doctrine exists because that exact error surfaced. The hub page opened by promising the course would "ensure compliance with OSHA standards" — a claim that survived every course-level audit because the audits, correctly, were scoped to the course. The marketing surface is part of the deliverable and gets audited for over-claims the same way the course does.
+
+## The Core Principle
+
+**A course teaches the standard — accurately, and cited to the source. It does not "ensure compliance."**
+
+The reason is structural, and it is the same regulation the course is built from: OSHA's training requirement (29 CFR 1910.147(c)(7)) is **workplace-specific by its own text**. The regulation requires authorized employees be trained in "the type and magnitude of the energy available *in the workplace*," and affected employees "in the purpose and use of *the* energy control procedure" — the employer's specific program, not a generic one. No off-the-shelf course can "ensure compliance" for a buyer's specific site, because compliance depends on the buyer's machines, procedures, and program — things the course has never seen. Compliance is the employer's, and it lives on their floor.
+
+Claiming otherwise is not just legally loose; it is the one place where the marketing contradicts everything the product is built on. A course whose entire value proposition is "we only say what the source says, and we show you where" cannot open with a sentence the source does not support. To a compliance-literate buyer — the person who decides — that opening sentence is a red flag, not a hook. It signals the vendor does not understand the standard well enough to know what a course can and cannot do.
+
+## The Honest Frame Is the Stronger Frame
+
+The correction is not a retreat. Say what is true, and it is a better pitch than the overclaim:
+
+> The course **teaches the standard accurately, with every claim cited to the regulation**, and equips a workforce to understand it. Compliance is the employer's, on their equipment — and a workforce that genuinely understands the standard is how an employer gets there.
+
+To the buyer who knows the regulation, that is the credible claim, and credibility is the whole sale. "Ensures compliance" asks them to trust a promise no vendor can keep; "teaches the standard, cited, so you can verify every line" hands them the proof and lets them check it. The second is stronger precisely because it claims less and demonstrates more.
+
+## What the Product Actually Is (the Differentiator)
+
+The thing worth selling is the thing no generic course can offer:
+
+- **Rendered from the authoritative source, not a template.** Anyone can ship a slick course; this one is built from the frozen regulation, and the freeze is provable.
+- **Checkable citations.** Every safety claim links back to the exact paragraph it came from. Reviewer mode lets a buyer verify the course *in the room*, before they trust it. That traceability is what a safety manager wants before signing.
+- **The citation loop.** The pitch is not "trust us" — it is "check us."
+
+## Roadmap: Close the Loop
+
+Today the loop runs `regulation → course → cited back to the regulation`. The next turn closes it: when a client's own SOPs become a frozen source, the loop becomes `company SOP → course → cited back to the SOP`. The client no longer just gets training — they get training where every claim points back to their own document, their own tribal knowledge, made durable and checkable. No generic vendor can sell that, because no generic vendor is rendering from *their* source. That is the product's long arc, and it is the same principle at a larger radius: render from the client's source, never create it.
+
+## The Standing Rule
+
+Never claim more than the source supports — in the course **or** the marketing. The marketing surface (hub, landing pages, one-pagers, decks) is part of the deliverable and is swept for over-claims in every audit, the same as the course. Two claims never appear: that the course *ensures* or *guarantees* compliance, and any regulatory assertion in the marketing that is not itself anchored to the source. Say what is true, cite where it comes from, and let the buyer verify. That is the entire positioning.
+
+---
+
+*Version 1.0 — 2026-07-16. Prompted by the "ensure compliance" overclaim caught in the third re-audit's friction set. The fix was five minutes of copy; the principle is permanent.*

--- a/docs/standards/course-audit-SPEC.md
+++ b/docs/standards/course-audit-SPEC.md
@@ -1,0 +1,101 @@
+# The Course-Audit Skill
+
+Specification for the adversarial audit that gates every course.
+Version 1.0 — 2026-07-16. Companion to the Durability Standard (§9) and the Build Methodology (§M4).
+
+## Preamble
+
+This is the executable form of the Durability Standard's acceptance test (§9) and the audit invoked by the Build Methodology's loop (§M4). Where the Standard says a course must survive an adversarial audit and the Methodology says the loop runs `self-check → independent audit → fix → re-audit`, this document is *what the audit actually does*.
+
+Two rules govern its use, and both are non-negotiable:
+
+- **The auditor's job is to find what is wrong, not to confirm it is right.** Approach every course adversarially. A reviewer who sets out to confirm a course is clean will confirm it; a reviewer who sets out to break it finds the breaks. "Zero findings" is a legitimate outcome — but only after looking hard. An auditor who finds nothing has usually not looked far enough.
+- **Auditor ≠ fixer.** The auditor is a fresh instance that did not write the course or its fixes, working with no memory of the build. The fixer never self-certifies. (The Methodology's pre-audit self-check runs the *same* passes before handoff — but that is the fixer clearing the surface, not the acceptance test. The acceptance test is always independent.)
+
+Work only from the frozen sources. Never audit from memory, prior knowledge of the regulation, or the open internet — those are the very failure modes the audit exists to catch.
+
+**Precondition — audit live `main`, not a stale premise.** Before auditing, confirm the content is actually on `main` (ancestor check plus reading live `main`, per Methodology §M5). An audit run against a stale or unmerged premise is worse than no audit.
+
+## Scope
+
+The audit covers the **entire deliverable** — every file a buyer or a learner could open:
+
+- the scripts, the build JSON, and the players *including their JavaScript* (hardcoded feedback strings are a content layer);
+- the README, decision records, provenance, image manifests, and any prompt files.
+
+Do **not** scope sweeps to `scripts/` + `builds/`. A path-scoped sweep is exactly how a phantom source line survived in a README through three audits. Records *of* the errors — audit documents, session logs, anything under `_quarantine/` — are excluded from findings.
+
+## The Six Passes
+
+### Pass 0 — Source Readiness
+Both frozen sources exist; their checksums recompute and match the provenance record; every authority the course cites is frozen — including cross-referenced standards (a term borrowed from another regulation requires *that* regulation frozen too). Any claim citing something unfrozen is a finding, and if a source is missing the audit halts here: the only finding is "freeze first."
+
+### Pass 1 — Source Fidelity, Claim by Claim
+Every safety or regulatory claim must grep-match a phrase in a frozen file. Every `source_ref` anchor must verify **verbatim** against the file it names — one exact span per anchor; a paraphrase inside an anchor is a finding, and a paraphrase wearing quotation marks is a worse one. Where a claim rests on two provisions, the anchor must hold two separately-marked spans, never one false continuous quote.
+
+High-yield tells (this course's history — check each explicitly):
+- **Count claims** — "recognizes N types," "N roles." (This course's founding errors were "five types" for six sources and "four roles" for three.)
+- **Authority phrasing** — "OSHA requires/defines…"; verify the exact count or list behind the attribution.
+- **Prohibition language** — a stated ban the source does not contain (the source has no master-key prohibition; that claim must read as program-design principle, not regulation).
+- **Trigger language** — the condition attached to an exception (an exception conditioned on *unavailability*, not "emergency").
+- **Numbers** — every figure is guilty until grep-proven against the source, or it is removed.
+
+### Pass 2 — Layer Consistency (both directions, and order)
+Script ↔ JSON ↔ player must tell the same story. Check all three of:
+- **Fabrication** — content in a build or player that is absent from the script.
+- **Loss** — content in the script absent from the build. (This project's regressions were losses, and they passed naive parity checks because JSON and player agreed on the lossy version.)
+- **Order** — where the source mandates a sequence, a step that is present but mis-ordered is still a violation. Verify the mandated order in *every* layer. (The final blocker was a correct, sourced notification placed one step too late.)
+
+Confirm slide-count parity **and** claim-level completeness across layers, and remember the non-obvious layers: any string a learner can read, including feedback strings in the player's JavaScript.
+
+### Pass 3 — Structural Coherence
+Separate from fidelity: content can be perfectly source-accurate and still be broken. Read *across* modules, not just within them. Check for redundancy, competing "most important" claims, sequencing problems, and contradictions between modules (e.g. a lock-removal rule stated absolutely in one module and excepted in another). Check **emphasis versus normative weight**: does the course's formatting emphasis track the source's "shall"? A mandatory requirement rendered as an aside, or an optional practice rendered as a rule, is a structural finding.
+
+### Pass 4 — Scope and Decisions
+Are folded-in exceptions taught with **all** their conditions? The most-abused exception is the canonical trap — an exception taught loosely reads as permission to skip the rule; taught with its full conditions and its misuse warned, it reads as expertise. Does every decision record match the shipped state? A record that reads "pending" while the package is represented as complete is a finding. Surface any new decision that belongs to the accountable signer — record it, route it, but do **not** resolve it inside the audit.
+
+### Pass 5 — Citation Feature Integrity
+In the player's reviewer mode, every rendered citation chip must verify against a frozen file — a rendered citation that cannot be verified is worse than none, because it invites a buyer to check and find it wrong. Confirm the toggle is fail-safe (renders nothing when the source data is incomplete) and delivery-safe (no browser-storage calls that break inside an LMS frame; a comment naming the constraint is fine).
+
+## The Two Guards
+
+These run alongside the passes. They exist because their absence let real defects through, one round at a time.
+
+### Guard G1 — Regression
+Diff the content that *prior* audits verified as present against the current layers. Report anything previously verified that is now missing. A fix can silently delete or displace correct content; two of this project's blockers were fixes going wrong on the same step.
+
+### Guard G2 — Completeness at Claim Level
+Confirm every taught claim — cited **or uncited** — survives into each build. Completeness checked at section-header granularity self-reports clean while individual claims are dropped below it. Go to claim level. (An uncited claim — "the roles aren't castes" — was dropped from a build and passed every section-level and parity check until claim-level completeness caught it.)
+
+## Named Tells
+
+Recurring signatures. Each earned its name in a real finding.
+
+- **Memory-blend error** — the founding failure class: a true-sounding claim given false authority ("recognizes five types," "four roles," "master keys are prohibited"). The idea may be reasonable; the *attribution to the source* is invented. This is the tell most worth internalizing — nearly every blocker was one.
+- **Reframe-is-a-finding** — if you catch yourself mentally rewording a claim to make it defensible, stop: that rewording is a finding, not a fix.
+- **Mis-attribution** — a claim can describe a real thing while filing it under the wrong standard ("qualified person" described accurately but attributed to lockout instead of the electrical standards).
+- **Partial-check miss** — verifying one claim in a section does not clear the section. The four-roles error hid beside a sibling claim that had "checked out."
+- **Build-guilty-until-proven** — never assume a build matches its script; verify it.
+- **Numbers guilty until grep-proven** — every figure is verified against the source or removed.
+- **Shared-typo proof** — an identical typo across two independently-fetched renderings is positive evidence they carry the same underlying text.
+- **Emphasis drift** — formatting weight that does not track the source's "shall" (a mandatory step buried, an optional one elevated).
+
+## Deliverable
+
+Write a dated finding list — `courses/<name>/AUDIT-YYYY-MM-DD.md`. For each finding:
+
+- a classification: **BLOCKER** (ships wrong; must fix before a prospect sees it), **FRICTION** (real but non-blocking), or **NOTE** (observation, no action required);
+- the exact file and locator;
+- the frozen-source paragraph it fails against.
+
+End with a plain verdict: **is this course defensible in front of a compliance-literate buyer — yes or no** — and, if no, exactly what blocks it. Close with a META section noting where the passes or guards felt incomplete, any finding that fit no pass, and any check you had to invent — that feedback hardens this spec.
+
+## Relationship to the Other Documents
+
+- **The Durability Standard §9** defines the audit *as an acceptance test* — the constitutional requirement. This spec is its executable form.
+- **The Build Methodology §M4** places the audit in the build loop and adds the pre-audit self-check. The fixer runs these passes to clear the surface; the acceptance test runs them independently.
+- The anchor schema referenced in Pass 1 belongs in the Durability Standard's atom schema; per-artifact flagging has not converged it, so it is being absorbed there.
+
+---
+
+*Version 1.0 — 2026-07-16. Hardened from three re-audit rounds on the LOTO build, folding in each round's META feedback: whole-surface scope, claim-level completeness, both-direction and order-aware layer checks, and the JavaScript content layer. Provisional in the sense every living document is — the next build that surprises it revises it.*


### PR DESCRIPTION
Adds the three governance documents to `docs/standards/`, alongside the existing Durability Standard. These were written and committed to this branch on 2026-07-16 but the original PR-open call hung, so they never reached `main` — which is why the rework (#72) couldn't find `BUILD-METHODOLOGY.md`/`course-audit-SPEC.md` and proceeded on the self-contained `REWORK-2026-07-16.md` instead.

- **`BUILD-METHODOLOGY.md`** — the operational *how*: build workflow, source-freeze protocol, rendering discipline, the audit loop (with the pre-audit self-check), and the process guards earned in real failures.
- **`course-audit-SPEC.md`** — the executable audit: six passes + two guards, whole-surface scope, claim-level completeness, named tells, deliverable format.
- **`POSITIONING.md`** — the honest-claim doctrine (teach the standard, cited; don't "ensure compliance").

Verified safe against current `main`: this branch changed *only* these three files relative to its merge-base (0 course files touched), so merging keeps all of the rework and simply adds the docs. Self-audited before commit; all three confirmed byte-identical to the self-audited versions. Not self-merged — governance docs are for the accountable signer to review and merge.

Note: two META items are flagged *inside* these docs as belonging elsewhere and not yet done — the anchor-grammar schema (→ Durability Standard's atom schema) and the topological merge gate (→ tooling). Plus two parked spec additions from the rework (the scar-test tell and the Gate-A orphan check) to fold in on the next spec-hardening pass.