### PR TITLE
LOTO demo-polish: citation chip fix + scene panel default

### DIFF
--- a/courses/loto/CHANGE-NOTE-demo-polish.md
+++ b/courses/loto/CHANGE-NOTE-demo-polish.md
@@ -1,0 +1,184 @@
+# CHANGE NOTE — LOTO demo polish (2026-07-24)
+
+Branch: `loto-demo-polish`, off `main` (post-#84/mobile-readability; unrelated
+file regions to the last several passes, no overlap expected).
+
+Status: plan committed before build (standing convention). Deviations and
+discoveries are called out explicitly in Results.
+
+---
+
+## Plan
+
+### Item 1 — citation chip position on image slides
+
+**Root cause, verified against `chrome/chrome.css` on `main` (brief asked
+for this explicitly).** The brief's diagnosis holds: line 65,
+`.slide.has-image > * { position: relative; z-index: 2; }` (2 classes,
+specificity (0,2,0)), beats the base `.citation-chip` rule's
+`position: absolute` (1 class, (0,1,0)) for any citation chip that is a
+direct child of an image slide — the chip drops into normal flow and lands
+wherever the centered content stack ends, instead of pinning bottom-right.
+
+**One correction to the brief's mechanism paragraph.** It describes the
+fix — adding `position: absolute` to the existing
+`.slide.has-image .citation-chip` block (line 779) — as "same (0,2,0)
+specificity ... wins the tie [by source order]." That block is actually
+three classes (`.slide`, `.has-image`, `.citation-chip`) = **(0,3,0)**, not
+(0,2,0) — it already outranks line 65's rule outright on specificity, no
+source-order tie-break needed (though it would also win that way, being
+later in the file). Doesn't change the fix; the brief's own "confirm in
+plan" instruction is exactly what caught this.
+
+**DOM parent — verified, does not need correcting.** The brief's scope
+conditionally includes `player.js` "only if the chip's DOM parent needs
+correcting." It doesn't: `renderCitation()`'s output is concatenated
+directly into `inner` in every `renderSlide()` branch (title, scene,
+callback, teaching-caption, misconception-held-up, reveal, definition,
+consolidation, options), and `inner` becomes the flat children of the outer
+`.slide` div — no wrapping element in between. `renderQuiz()`/`renderClose()`
+never set `has-image` at all, so the bug can't occur there regardless.
+Confirmed by DOM measurement (see below), not just by reading the template
+strings. **`player.js` is not touched this pass.**
+
+**Confirmed live, quantitatively, before writing any CSS** (module-01,
+1440×900, slide 7 — `teaching-caption`, has-image, has a citation source):
+chip bounding box top/bottom = 554/580 against a slide height of 833 — nowhere
+near the bottom edge, and in this specific case overlapping the body text's
+last line ("...press and clamp and lift.") rather than merely floating
+mid-slide. Slide 6 (`definition`, no image, has a citation source) in the
+same session: chip bottom = 819.5 against the same 833 slide height — a
+13.5px margin, exactly `1.5vh` of the 900px viewport. So the plain-slide case
+already behaves correctly; only the has-image case is broken, as diagnosed.
+
+**Fix:** add `position: absolute;` to the existing `.slide.has-image
+.citation-chip` block. No other property in that block needs to change —
+`right`/`bottom`/`z-index` are unaffected by this bug (they're not touched
+by the line-65 override) and don't need restating.
+
+### Item 2 — scene-text legibility over background art
+
+**Sean's reference point, verified.** "The panel treatment (as on the 'THE
+PROBLEM' reveal)" — module-01 slide index 3 — is actually a `definition`
+container, not `reveal` (label "The Problem", type `definition`). What
+reads well there is `.definition-box`'s has-image variant:
+`background: rgba(20, 26, 22, 0.55); border-color: rgba(244, 237, 224,
+0.28); backdrop-filter: blur(2px);` (chrome.css:118-122) plus the box's own
+padding/border-radius (chrome.css:110-117) and `color: var(--onimage-ink)`
+on the boxed text (chrome.css:130). Naming aside, this is exactly the
+precedent to extend — a real panel with its own opaque-ish background,
+independent of whatever is directly behind it.
+
+**Why the current scene treatment is weaker, mechanically.** `.slide.
+has-image::before` is a `radial-gradient(ellipse at center, ...0.35 ... 0%,
+...0.86... 100%)` (chrome.css:58-64) — darkest at the *edges*, lightest
+(0.35 opacity) at the *center*. `.slide` centers its content both axes
+(`align-items: center; justify-content: center; text-align: center`), so
+scene text sits exactly where the whole-slide scrim is weakest. Scene text
+also has no boxed/bordered treatment of its own today (chrome.css:310-332)
+— it depends entirely on that center-weak scrim plus `color:
+var(--onimage-ink)`. This is a plausible root mechanism for Sean's "hard to
+read" note, not just an aesthetic judgment call.
+
+**Target check slide, verified visually (not assumed from label text).**
+Module 1 has three `scene` slides; two carry images (index 1 `tuesday-
+morning.jpg`, index 2 `working-inside.jpg`); index 22 has no image and is
+irrelevant to this item. Rendered both: index 2 (label "Scene" — worker
+mid-repair, wrench on an open roller-bearing housing, sparks/glow from the
+housing interior) is both the busier art (more visual complexity, a bright
+glow directly behind the third line of text) and the longer/busier text of
+the two ("He presses the stop button. The belt slows. Stops. He opens the
+access panel, pulls out a wrench, and starts loosening a bolt on the roller
+bearing."). This is **module-01 slide index 2** — the "M1 slide with the
+maintenance-scene art" the brief's check refers to.
+
+**Default (ship this): extend the definition-box panel vocabulary to
+`.slide.has-image.slide-scene p`.** Reuse the identical rgba values already
+established for on-image panels (`.definition-box`, `.option`,
+`.citation-chip` all use this same rgba(20,26,22,·) / rgba(244,237,224,·)
+pair) — "tokens only" per the brief, read as *stay inside the existing
+fixed on-image palette, don't invent new colors*, since these values aren't
+literal CSS custom properties but are the de facto token vocabulary for
+"glass panel over image" everywhere else in the file. `<p>` is already a
+block element with `max-width: 38ch`, so backing it with
+padding/border/border-radius/backdrop-filter produces the same contained-
+panel look as `.definition-box` **with no markup change** — no wrapping
+element needed, so `player.js` stays untouched for this item too, consistent
+with the scope note above. `.scene-label` (the small uppercase kicker) stays
+unpaneled, matching `.definition-label`'s precedent of sitting outside the
+box — to be confirmed empirically, not assumed (see Verification).
+
+**Alternates (capture only, evidence branch, not shipped):**
+- **(a) Strengthened localized scrim** — a horizontal dark band
+  (`linear-gradient`, transparent → ~0.75 opacity → transparent) behind the
+  centered text zone specifically, wider darkening than the whole-slide
+  vignette but no box/border — closer to a subtitle-band look.
+- **(b) Tuned text-shadow** — no background at all; a multi-layer
+  `text-shadow` on the scene paragraph (and label) for contrast without
+  occluding any of the art.
+
+Both applied as temporary CSS, captured at the same slide/viewports/modes as
+the default, then reverted — `chrome.css` ships only the default.
+
+**Explicitly out of scope, noted not fixed:** the same weak-center-scrim
+mechanism plausibly affects other has-image register types (teaching-
+caption, misconception-held-up, reveal, callback) to varying degrees, but
+the brief scopes this item to scene text only and its own check requires
+"no change to non-scene slide types" — flagging the pattern for a future
+backlog item, not touching it here. Also out of scope, staying in
+`CHROME-CSS-CLEANUP-QUEUED.md` per the brief's Scope section: the stark-cut
+`pre-line` removal, popover dark-mode elevation, and `restartQuiz()`'s
+pre-existing `updateProgress()` gap (confirmed still present by reading
+`player.js:370-376` — noted, not touched).
+
+### Verification plan
+
+1. **Composite-contrast check (new tooling).** No contrast-checking utility
+   exists in `tools/capture` yet — building
+   `tools/capture/contrast-check.js`: for a given selector, sample actual
+   rendered pixels from a deterministic screenshot (not token pairs) near
+   the element's box edges for the background, read the element's computed
+   text color, compute WCAG relative luminance/contrast ratio, and apply the
+   correct AA threshold (3:1 large text ≥24px regular or ≥18.66px bold at
+   that specific viewport's computed size, else 4.5:1) — per the Slide-Type
+   Standard's explicit "verified on the rendered composite, not token pairs
+   in isolation" requirement. Run against slide index 2, both the paneled
+   `p` and the unpaneled `.scene-label`, at 1440 and 390, both modes. This
+   also decides the open question above (does the label need its own
+   treatment) from measurement rather than assumption.
+2. **Citation chip captures.** Slide 7 (has-image) and slide 6 (plain),
+   Reviewer mode on, both modes, desktop 1440 + 390 — before/after,
+   confirming bottom-right pinning and that the `> *` override no longer
+   applies (measured via `getBoundingClientRect`, not just eyeballed).
+3. **Scene default + both alternates.** Slide index 2, desktop 1440 + 390,
+   both modes — before/after for the default (shipped), plus the two
+   alternates (evidence branch only).
+4. **M2/M3 scene sweep, read-only.** `chrome.css` is shared verbatim across
+   all three modules, so the panel treatment reaches any M2/M3 has-image
+   scene slides for free — capturing them too as supporting evidence, no
+   content/data changes, not a gate (the brief's formal check is M1's
+   slide only).
+5. **Overflow-audit regression gate** (`tools/capture/overflow-audit.js`)
+   against the #84 baseline (`courses/loto/screenshots/mobile-readability/
+   overflow-after.json` on `main`) — zero new clipped-and-unscrollable
+   slides. Neither change should affect layout height/width, but this is
+   the established regression gate for this deck per prior passes.
+6. **Desktop pixel-diff vs `main`**, all M1 slides, both modes — expect
+   0.0000% everywhere except: slides with a citation chip on a has-image
+   slide (item 1), and has-image scene slides (item 2). Any other slide
+   showing a diff is a regression, not an intended change.
+
+All captures + the contrast-check output + overflow-audit JSON go to
+`evidence/demo-polish` (never merged), linked from the PR body — nothing
+lands on the PR branch but `chrome.css`, this change note, and the
+`tools/capture` extension, per the evidence-branch convention
+(WORKFLOW-TRACE addendum C, T21).
+
+### Not in scope
+
+Everything in `CHROME-CSS-CLEANUP-QUEUED.md` items 1–3 (stark-cut cleanup,
+popover elevation, `restartQuiz()` progress gap). No module shells, no
+`MODULE`/`MODULE_CHROME` data, no menu file. `player.js` is not touched by
+either item in this pass (both confirmed above).
+
+---

--- a/courses/loto/CHANGE-NOTE-demo-polish.md
+++ b/courses/loto/CHANGE-NOTE-demo-polish.md
@@ -182,3 +182,128 @@ popover elevation, `restartQuiz()` progress gap). No module shells, no
 either item in this pass (both confirmed above).
 
 ---
+
+## Results
+
+### Item 1 — citation chip
+
+Shipped exactly the planned fix: `position: absolute;` added to
+`.slide.has-image .citation-chip` (chrome.css:779–787). No other property
+changed; `right`/`bottom`/`z-index` were never affected by the bug.
+
+Confirmed live, before and after, via `getBoundingClientRect()` logged by
+the capture recipe — not just eyeballed. Before: slide 7 (has-image)
+chip top/bottom = 554/580 of an 833-tall slide, overlapping the body
+text's last line; slide 6 (plain) chip bottom = 819.5, correctly pinned.
+After: **slide 7's chip rect is pixel-identical to slide 6's** at both
+viewports —
+
+| | 1440×900 | 390×844 |
+|---|---|---|
+| slide 7 (image), after | `{x:1282.8, y:793.3, right:1418.4, bottom:819.5}` | `{x:248.5, y:736.5, right:384.2, bottom:762.7}` |
+| slide 6 (plain), after | `{x:1282.8, y:793.3, right:1418.4, bottom:819.5}` | `{x:248.5, y:736.5, right:384.2, bottom:762.7}` |
+
+Same numbers to four decimal places, both viewports, both modes (the
+on-image color variant is the only remaining difference, which is correct
+and pre-existing). Screenshots confirm visually:
+`evidence/demo-polish` → `chip/`.
+
+The fix is a plain CSS rule keyed on `.citation-chip`/`.has-image`, not
+slide-type-conditional, so it applies uniformly to every `renderSlide()`
+branch — verified structurally in the Plan, and spot-verified live on one
+representative case (`teaching-caption`) rather than re-proving the same
+mechanism per slide type.
+
+### Item 2 — scene panel
+
+Shipped the planned default: the definition-box glass-panel treatment
+(same rgba pair, same border-radius/padding/backdrop-filter vocabulary)
+extended to `.slide.has-image.slide-scene p` (chrome.css:321–337).
+
+**Deviation from the plan, driven by measurement.** The plan proposed
+leaving `.scene-label` unpaneled, matching `.definition-label`'s
+precedent, "to be confirmed empirically, not assumed." It wasn't
+confirmed — `contrast-check.js` measured the label at **3.12–3.45:1**
+against module-01 slide 2's actual rendered pixels (warm mid-tones near
+the hard hat/machinery), against a 4.5:1 floor for text this size. Rather
+than brighten the label's color (which would pass by measurement here but
+break the dim-kicker convention every other on-image label/kicker in this
+file follows — a register-hierarchy inconsistency, not a one-off), it now
+gets the same panel treatment as the paragraph (chrome.css:311–320),
+producing a small label pill sitting just above the text panel. Visually
+checked at both viewports, both modes — reads as an intentional
+label-plus-caption pairing, not a layout accident.
+
+**Composite-contrast check (`contrast-check.js`, new — see Plan for the
+technique), all 8 viewport×mode×element combinations: PASS.**
+
+| Viewport | Mode | Element | Font size | Threshold | Ratio | Result |
+|---|---|---|---|---|---|---|
+| 1440×900 | light | `p` | 24.8px | 3:1 (large) | 8.57 | PASS |
+| 1440×900 | light | `.scene-label` | 12.5px | 4.5:1 | 6.88 | PASS |
+| 1440×900 | dark | `p` | 24.8px | 3:1 (large) | 8.57 | PASS |
+| 1440×900 | dark | `.scene-label` | 12.5px | 4.5:1 | 6.88 | PASS |
+| 390×844 | light | `p` | 16.8px | 4.5:1 | 9.70 | PASS |
+| 390×844 | light | `.scene-label` | 12.5px | 4.5:1 | 6.88 | PASS |
+| 390×844 | dark | `p` | 16.8px | 4.5:1 | 9.70 | PASS |
+| 390×844 | dark | `.scene-label` | 12.5px | 4.5:1 | 6.88 | PASS |
+
+(Full data, including worst-case sample point and background RGB per row:
+`evidence/demo-polish/contrast-report.json`.) The `p` threshold changes
+between viewports because its `clamp()` font-size crosses the WCAG
+large-text line (≥24px) at 1440 but not at 390 — the checker reads the
+actual computed size per viewport rather than assuming one threshold.
+
+**Shipped vs. selection.** Per the brief, the default is what ships in
+this PR — Sean has not yet chosen between it and the two alternates below;
+that happens at his device check, same as any other handback. If he
+prefers an alternate, that's a follow-up swap, not cause to reopen this
+PR. Whichever he picks is a pending Slide-Type Standard amendment per the
+brief (not applied to the standard in this pass).
+
+**Alternates, captured only (`evidence/demo-polish/scene/*-alt-*.png`),
+not in `chrome.css`:**
+- (a) strengthened localized scrim — a horizontal dark band
+  (`linear-gradient`, transparent → 0.78 → transparent) behind the text
+  zone, no box.
+- (b) tuned text-shadow — no background at all; multi-layer shadow on the
+  paragraph and label.
+
+**M2/M3 sweep (read-only, no data/content changes):** module-02 has no
+has-image scene slides (nothing to capture). module-03 slides 1 and 9 both
+receive the same panel treatment for free, since `chrome.css` is shared
+verbatim — captured and visually confirmed clean at both viewports, both
+modes (`evidence/demo-polish/scene/module-03-*`).
+
+### Regression gates
+
+**Overflow audit** (`tools/capture/overflow-audit.js`, re-run against the
+fixed tree): 736 checks, 2 clipped, 0 clipped-and-unscrollable —
+**field-for-field identical** to the #84 baseline
+(`courses/loto/screenshots/mobile-readability/overflow-after.json` on
+`main`): same two rows (module-03 slide-7, the 360×660-chrome stress
+viewport, both modes), same `scrollWorks: true`. Zero regressions,
+confirmed by diff, not by matching aggregate counts.
+
+**Desktop pixel-diff, full deck, both modes** (184 waypoints — every
+slide, quiz question, and close screen across all three modules, Learner
+mode): **8 of 184 changed**, and all 8 are exactly the has-image scene
+slides this pass touches — module-01 slides 2/3 (1-indexed), module-03
+slides 2/10 (1-indexed), each ×2 modes. Nothing else in the deck moved.
+(Learner mode was used for this sweep, matching the deck's default state;
+it doesn't exercise the citation chip, which is covered directly and
+separately above — the two fixes don't overlap on any single slide in
+this deck, so one full-deck sweep in the default view already accounts
+for every unintended-change risk.) Report:
+`evidence/demo-polish/full-deck-diff-report.json`.
+
+### Self-check
+
+| ID | Check | Result |
+|---|---|---|
+| P1 | Diff confined to scope; `main` gains no capture artifacts | **PASS** — `git diff --stat main` (this branch): `chrome.css`, this change note, `tools/capture/{loto-player.js,contrast-check.js,demo-polish.recipe.js}` only. All captures on `evidence/demo-polish`, never this branch. |
+| P2 | Citation chip bottom-right on image + plain slides, Reviewer mode, both modes, both widths; `> *` override no longer applies | **PASS** — rects pixel-identical between image and plain slides at both viewports/modes (table above); confirmed via `getBoundingClientRect()`, not eyeballed. |
+| P3 | Shipped scene treatment matches Sean's selection (recorded in change note); alternates present in evidence branch | **Shipped = the brief's specified default** (Sean's selection among default/alternates is a post-handback step, not yet made — see above). Both alternates present: `evidence/demo-polish/scene/*-alt-scrim.png`, `*-alt-shadow.png`. |
+| P4 | Overflow audit: zero regressions vs #84 baseline; no unintended visual change outside scene text + chip | **PASS** — overflow field-for-field identical to baseline; full-deck pixel-diff shows changes on exactly the 4 intended has-image scene slides (×2 modes) and nowhere else. |
+
+No console/page errors observed across any capture or audit run.

--- a/courses/loto/builds/chrome/chrome.css
+++ b/courses/loto/builds/chrome/chrome.css
@@ -317,7 +317,23 @@ body {
   color: var(--ink-dim);
   margin-bottom: 1.5vh;
 }
-.slide.has-image.slide-scene .scene-label { color: var(--onimage-ink-dim); }
+/* DEMO-POLISH-2026-07-24: measured (contrast-check.js), not assumed — the
+   label unpaneled (matching .definition-label's precedent of sitting
+   outside its box) fails AA on the busiest scene slide: 3.12-3.45:1 against
+   this image's warm mid-tones, vs the 4.5:1 small-text floor. Swapping to
+   the brighter --onimage-ink token instead would pass by measurement here,
+   but every other on-image kicker/label in this file uses the dim ink
+   consistently (a register-hierarchy convention, not a one-off) — panel it
+   like the paragraph instead of breaking that pattern for scene alone. */
+.slide.has-image.slide-scene .scene-label {
+  color: var(--onimage-ink-dim);
+  display: inline-block;
+  background: rgba(20, 26, 22, 0.55);
+  border: 1px solid rgba(244, 237, 224, 0.28);
+  border-radius: 3px;
+  padding: 0.5em 0.9em;
+  backdrop-filter: blur(2px);
+}
 .slide-scene p {
   font-family: var(--font-body);
   font-style: italic;
@@ -327,7 +343,22 @@ body {
   color: var(--ink-dim);
   max-width: 38ch;
 }
-.slide.has-image.slide-scene p { color: var(--onimage-ink); }
+/* DEMO-POLISH-2026-07-24: the whole-slide scrim (.slide.has-image::before)
+   is a radial gradient, weakest at center — exactly where centered scene
+   text sits — so it can't carry text contrast alone (Sean's device note).
+   Default treatment: extend the same glass-panel vocabulary already used
+   for .definition-box/.option/.citation-chip on images (identical rgba
+   pair) to the scene paragraph itself, giving it its own local contrast
+   independent of what's behind it. The label above gets the same panel
+   for the same reason, measured — see that rule's comment. */
+.slide.has-image.slide-scene p {
+  color: var(--onimage-ink);
+  background: rgba(20, 26, 22, 0.55);
+  border: 1px solid rgba(244, 237, 224, 0.28);
+  border-radius: 3px;
+  padding: 2.5vh 3vw;
+  backdrop-filter: blur(2px);
+}
 .slide-scene em { color: var(--accent); font-style: normal; font-weight: 600; }
 .slide.has-image.slide-scene em { color: var(--onimage-ink); text-decoration: underline; text-decoration-color: rgba(244,237,224,0.5); }
 
@@ -777,6 +808,11 @@ body {
   text-decoration: none;
 }
 .slide.has-image .citation-chip {
+  /* Restores position:absolute against the scrim-lifting rule above
+     (.slide.has-image > *, (0,2,0)) — this selector is (0,3,0) and already
+     wins outright; without this, the chip drops into normal flow and lands
+     wherever the centered content stack ends (DEMO-POLISH-2026-07-24). */
+  position: absolute;
   background: rgba(20,26,22,0.65);
   border-color: rgba(244,237,224,0.3);
   color: var(--onimage-ink-dim);

--- a/tools/capture/contrast-check.js
+++ b/tools/capture/contrast-check.js
@@ -1,0 +1,127 @@
+'use strict';
+
+// Composite-contrast checker (DEMO-POLISH-2026-07-24). Per the Slide-Type
+// Standard §S5: "contrast is verified on the rendered composite ... not on
+// token pairs in isolation." No prior tool in this directory measured
+// actual rendered pixels against text color — this fills that gap.
+//
+// Technique: render normally to read the element's real computed text
+// color/size/weight, then re-render with that element's text made
+// transparent (so glyph pixels can't contaminate the sample) and read the
+// pixels actually sitting behind it — the image, the scrim, and/or a panel
+// background, whatever is really there. Reports the WORST-CASE point in the
+// element's box, not an average — AA requires the text to be legible
+// everywhere it appears, not just on average.
+
+const { PNG } = require('pngjs');
+
+function srgbToLinear(c) {
+  const v = c / 255;
+  return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4);
+}
+
+function relativeLuminance([r, g, b]) {
+  return 0.2126 * srgbToLinear(r) + 0.7152 * srgbToLinear(g) + 0.0722 * srgbToLinear(b);
+}
+
+function contrastRatio(rgbA, rgbB) {
+  const La = relativeLuminance(rgbA);
+  const Lb = relativeLuminance(rgbB);
+  const lighter = Math.max(La, Lb);
+  const darker = Math.min(La, Lb);
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function parseRgb(str) {
+  const m = str.match(/rgba?\(([^)]+)\)/);
+  const parts = m[1].split(',').map((s) => parseFloat(s.trim()));
+  return [parts[0], parts[1], parts[2]];
+}
+
+// WCAG AA: large text (>=24px, or >=18.66px and bold) needs 3:1; else 4.5:1.
+function aaThreshold(fontSizePx, fontWeight) {
+  const isBold = fontWeight >= 700;
+  const isLarge = fontSizePx >= 24 || (isBold && fontSizePx >= 18.66);
+  return isLarge ? 3.0 : 4.5;
+}
+
+function worstCasePoint(png, box, scale) {
+  const cols = 7, rows = 5;
+  const insetX = Math.max(2, box.width * 0.06);
+  const insetY = Math.max(2, box.height * 0.1);
+  const points = [];
+  for (let i = 0; i < cols; i++) {
+    for (let j = 0; j < rows; j++) {
+      const cssX = box.x + insetX + (box.width - 2 * insetX) * (cols === 1 ? 0.5 : i / (cols - 1));
+      const cssY = box.y + insetY + (box.height - 2 * insetY) * (rows === 1 ? 0.5 : j / (rows - 1));
+      const x = Math.round(cssX * scale);
+      const y = Math.round(cssY * scale);
+      if (x < 0 || y < 0 || x >= png.width || y >= png.height) continue;
+      const idx = (png.width * y + x) << 2;
+      points.push({ x, y, rgb: [png.data[idx], png.data[idx + 1], png.data[idx + 2]] });
+    }
+  }
+  return points;
+}
+
+// Measures composite contrast for `selector`'s own text against whatever
+// actually renders behind it. `page` must already be settled on the state
+// to measure. Mutates and restores the element's inline color.
+async function measureContrast(page, selector) {
+  const info = await page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    if (!el) return null;
+    const cs = getComputedStyle(el);
+    const r = el.getBoundingClientRect();
+    return {
+      color: cs.color,
+      fontSize: parseFloat(cs.fontSize),
+      fontWeight: parseFloat(cs.fontWeight),
+      box: { x: r.x, y: r.y, width: r.width, height: r.height },
+    };
+  }, selector);
+  if (!info || info.box.width === 0 || info.box.height === 0) return null;
+
+  // Make the element's own text invisible (inline style — highest
+  // precedence on the element itself) so the "behind" screenshot samples
+  // real background pixels, never glyph-antialiasing pixels.
+  await page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    el.dataset.__prevColor = el.style.color;
+    el.style.color = 'transparent';
+  }, selector);
+
+  const viewport = page.viewportSize();
+  const buffer = await page.screenshot();
+
+  await page.evaluate((sel) => {
+    const el = document.querySelector(sel);
+    el.style.color = el.dataset.__prevColor || '';
+    delete el.dataset.__prevColor;
+  }, selector);
+
+  const png = PNG.sync.read(buffer);
+  const scale = png.width / viewport.width;
+  const textRgb = parseRgb(info.color);
+  const samples = worstCasePoint(png, info.box, scale).map((p) => ({
+    ...p,
+    ratio: contrastRatio(textRgb, p.rgb),
+  }));
+  if (!samples.length) return null;
+  const worst = samples.reduce((a, b) => (b.ratio < a.ratio ? b : a));
+  const threshold = aaThreshold(info.fontSize, info.fontWeight);
+
+  return {
+    selector,
+    textRgb,
+    fontSize: Math.round(info.fontSize * 100) / 100,
+    fontWeight: info.fontWeight,
+    worstCaseBg: worst.rgb,
+    worstCasePoint: { x: worst.x, y: worst.y },
+    contrastRatio: Math.round(worst.ratio * 100) / 100,
+    threshold,
+    pass: worst.ratio >= threshold,
+  };
+}
+
+module.exports = { measureContrast, contrastRatio, relativeLuminance, aaThreshold };

--- a/tools/capture/demo-polish.recipe.js
+++ b/tools/capture/demo-polish.recipe.js
@@ -1,0 +1,258 @@
+'use strict';
+
+// Capture recipe for DEMO-POLISH-2026-07-24. Run with:
+//   node demo-polish.recipe.js before       (pre-fix — stash chrome.css first)
+//   node demo-polish.recipe.js after        (post-fix, shipped default)
+//   node demo-polish.recipe.js contrast     (AA composite-contrast report, current tree)
+//   node demo-polish.recipe.js alt-scrim    (item 2 alternate (a), evidence only)
+//   node demo-polish.recipe.js alt-shadow   (item 2 alternate (b), evidence only)
+//
+// Item 1 (citation chip): module-01 slide 7 (has-image+source) and slide 6
+// (plain+source), Reviewer mode on, desktop 1440 + phone 390, both modes.
+// Item 2 (scene panel): module-01 slide 2 (the gate — busiest/maintenance-
+// scene art) + module-03 slides 1/9 (has-image scene, read-only supporting
+// sweep — chrome.css is shared verbatim, so the fix reaches them for free).
+
+const path = require('path');
+const fs = require('fs');
+const { chromium } = require('playwright');
+const { serveDir, newDeterministicPage, settle, shoot } = require('./lib');
+const { setDarkMode, setReviewerMode } = require('./loto-player');
+const { measureContrast } = require('./contrast-check');
+
+const REPO_ROOT = path.resolve(__dirname, '..', '..');
+const BUILDS_DIR = path.join(REPO_ROOT, 'courses', 'loto', 'builds');
+const OUT_DIR = path.join(REPO_ROOT, 'courses', 'loto', 'screenshots', 'demo-polish');
+
+const DESKTOP = { name: '1440x900', width: 1440, height: 900 };
+const PHONE = { name: '390x844', width: 390, height: 844 };
+const VIEWPORTS = [DESKTOP, PHONE];
+const MODES = ['light', 'dark'];
+
+const CHIP_WAYPOINTS = [
+  { name: 'slide7-image', index: 7 },
+  { name: 'slide6-plain', index: 6 },
+];
+const SCENE_GATE = { module: 'module-01', name: 'slide2-target', index: 2 };
+const SCENE_SWEEP = [
+  { module: 'module-03', name: 'slide1', index: 1 },
+  { module: 'module-03', name: 'slide9', index: 9 },
+];
+
+async function gotoSlide(page, index) {
+  await page.evaluate((i) => {
+    quizMode = false;
+    currentSlide = i;
+    renderSlide();
+    updateProgress();
+    updateNavButtons();
+  }, index);
+}
+
+async function captureChip(browser, port, tag) {
+  for (const viewport of VIEWPORTS) {
+    for (const mode of MODES) {
+      const page = await newDeterministicPage(browser, viewport);
+      await page.goto(`http://127.0.0.1:${port}/module-01/index.html`);
+      await settle(page);
+      const isPhoneWidth = viewport.name === PHONE.name;
+      await setDarkMode(page, { isPhoneWidth, wantDark: mode === 'dark' });
+      await setReviewerMode(page, { isPhoneWidth, wantReviewer: true });
+      for (const wp of CHIP_WAYPOINTS) {
+        await gotoSlide(page, wp.index);
+        await settle(page);
+        await shoot(page, path.join(OUT_DIR, 'chip', `${viewport.name}-${mode}-${wp.name}-${tag}.png`));
+        const rects = await page.evaluate(() => {
+          const chip = document.querySelector('.citation-chip');
+          const slide = document.querySelector('.slide');
+          return chip && slide
+            ? { chip: chip.getBoundingClientRect().toJSON(), slide: slide.getBoundingClientRect().toJSON() }
+            : null;
+        });
+        console.log(`chip ${viewport.name}/${mode}/${wp.name}/${tag}:`, JSON.stringify(rects));
+      }
+      if (page.errors.length) console.error(`Errors ${viewport.name}/${mode}:`, page.errors.map((e) => e.message));
+      await page.close();
+    }
+  }
+}
+
+async function captureScene(browser, port, tag) {
+  const all = [SCENE_GATE, ...SCENE_SWEEP];
+  for (const viewport of VIEWPORTS) {
+    for (const mode of MODES) {
+      for (const wp of all) {
+        const page = await newDeterministicPage(browser, viewport);
+        await page.goto(`http://127.0.0.1:${port}/${wp.module}/index.html`);
+        await settle(page);
+        const isPhoneWidth = viewport.name === PHONE.name;
+        await setDarkMode(page, { isPhoneWidth, wantDark: mode === 'dark' });
+        await gotoSlide(page, wp.index);
+        await settle(page);
+        await shoot(page, path.join(OUT_DIR, 'scene', `${wp.module}-${viewport.name}-${mode}-${wp.name}-${tag}.png`));
+        if (page.errors.length) {
+          console.error(`Errors ${wp.module}/${viewport.name}/${mode}:`, page.errors.map((e) => e.message));
+        }
+        await page.close();
+      }
+    }
+  }
+}
+
+async function runContrast(browser, port) {
+  const results = [];
+  for (const viewport of VIEWPORTS) {
+    for (const mode of MODES) {
+      const page = await newDeterministicPage(browser, viewport);
+      await page.goto(`http://127.0.0.1:${port}/module-01/index.html`);
+      await settle(page);
+      await setDarkMode(page, { isPhoneWidth: viewport.name === PHONE.name, wantDark: mode === 'dark' });
+      await gotoSlide(page, SCENE_GATE.index);
+      await settle(page);
+      for (const sel of ['.slide-scene p', '.slide-scene .scene-label']) {
+        const r = await measureContrast(page, sel);
+        results.push({ viewport: viewport.name, mode, ...r });
+      }
+      await page.close();
+    }
+  }
+  fs.mkdirSync(OUT_DIR, { recursive: true });
+  fs.writeFileSync(path.join(OUT_DIR, 'contrast-report.json'), JSON.stringify(results, null, 2));
+  console.log(JSON.stringify(results, null, 2));
+  const allPass = results.every((r) => r.pass);
+  console.log(allPass ? 'CONTRAST: ALL PASS' : 'CONTRAST: FAIL');
+  return allPass;
+}
+
+// Alternates (a)/(b) — evidence only, never shipped. Neutralizes the
+// shipped default via !important overrides injected at capture time, so
+// this works regardless of what's on disk; chrome.css itself is untouched.
+const ALT_CSS = {
+  'alt-scrim': `
+    .slide.has-image.slide-scene p {
+      background: none !important; border: none !important;
+      padding: 0 !important; backdrop-filter: none !important;
+    }
+    .slide.has-image.slide-scene::after {
+      content: '';
+      position: absolute; inset: 0; z-index: 1;
+      background: linear-gradient(180deg, transparent 0%, rgba(8,11,9,0.78) 30%, rgba(8,11,9,0.78) 70%, transparent 100%);
+    }
+  `,
+  'alt-shadow': `
+    .slide.has-image.slide-scene p {
+      background: none !important; border: none !important;
+      padding: 0 !important; backdrop-filter: none !important;
+      text-shadow: 0 1px 3px rgba(0,0,0,0.95), 0 2px 10px rgba(0,0,0,0.85), 0 0 24px rgba(0,0,0,0.6);
+    }
+    .slide.has-image.slide-scene .scene-label {
+      text-shadow: 0 1px 3px rgba(0,0,0,0.95), 0 2px 8px rgba(0,0,0,0.8);
+    }
+  `,
+};
+
+async function captureAlt(browser, port, altName) {
+  for (const viewport of VIEWPORTS) {
+    for (const mode of MODES) {
+      const page = await newDeterministicPage(browser, viewport);
+      await page.goto(`http://127.0.0.1:${port}/${SCENE_GATE.module}/index.html`);
+      await settle(page);
+      await page.addStyleTag({ content: ALT_CSS[altName] });
+      await setDarkMode(page, { isPhoneWidth: viewport.name === PHONE.name, wantDark: mode === 'dark' });
+      await gotoSlide(page, SCENE_GATE.index);
+      await settle(page);
+      await shoot(page, path.join(OUT_DIR, 'scene', `${SCENE_GATE.module}-${viewport.name}-${mode}-${SCENE_GATE.name}-${altName}.png`));
+      await page.close();
+    }
+  }
+}
+
+// Full-deck desktop sweep, all three modules — the regression gate. Prior
+// passes learned (T6, PR #80) that a sampled gate can miss a real
+// regression a full matrix catches; no sampling here.
+const DECK_COUNTS = {
+  'module-01': { slides: 25, quiz: 4 },
+  'module-02': { slides: 22, quiz: 4 },
+  'module-03': { slides: 30, quiz: 4 },
+};
+
+function deckWaypoints(counts) {
+  const wps = [];
+  for (let i = 0; i < counts.slides; i++) wps.push({ name: `slide-${i + 1}`, type: 'slide', index: i });
+  for (let i = 0; i < counts.quiz; i++) wps.push({ name: `quiz-${i + 1}`, type: 'quiz', index: i });
+  wps.push({ name: 'close', type: 'close' });
+  return wps;
+}
+
+async function gotoDeckWaypoint(page, wp) {
+  await page.evaluate((wp) => {
+    if (wp.type === 'slide') {
+      quizMode = false;
+      currentSlide = wp.index;
+      renderSlide();
+    } else if (wp.type === 'quiz') {
+      quizMode = true;
+      currentQuizQuestion = wp.index;
+      isAnswered = false;
+      renderQuiz();
+    } else if (wp.type === 'close') {
+      quizMode = true;
+      quizAnswers = MODULE.quiz.map((q) => q.correct);
+      currentQuizQuestion = MODULE.quiz.length - 1;
+      isAnswered = true;
+      renderClose();
+    }
+    updateProgress();
+    updateNavButtons();
+  }, wp);
+}
+
+async function captureFullDeck(browser, port, tag) {
+  for (const [mod, counts] of Object.entries(DECK_COUNTS)) {
+    for (const mode of MODES) {
+      const page = await newDeterministicPage(browser, DESKTOP);
+      await page.goto(`http://127.0.0.1:${port}/${mod}/index.html`);
+      await settle(page);
+      await setDarkMode(page, { isPhoneWidth: false, wantDark: mode === 'dark' });
+      for (const wp of deckWaypoints(counts)) {
+        await gotoDeckWaypoint(page, wp);
+        await settle(page);
+        await shoot(page, path.join(OUT_DIR, 'full-deck', `${mod}-${DESKTOP.name}-${mode}-${wp.name}-${tag}.png`));
+      }
+      if (page.errors.length) console.error(`Errors ${mod}/${mode}:`, page.errors.map((e) => e.message));
+      await page.close();
+    }
+  }
+}
+
+async function main() {
+  const tag = process.argv[2];
+  const { server, port } = await serveDir(BUILDS_DIR);
+  const browser = await chromium.launch();
+  try {
+    if (tag === 'before' || tag === 'after') {
+      await captureChip(browser, port, tag);
+      await captureScene(browser, port, tag);
+    } else if (tag === 'full-deck-before' || tag === 'full-deck-after') {
+      await captureFullDeck(browser, port, tag === 'full-deck-before' ? 'before' : 'after');
+    } else if (tag === 'contrast') {
+      const pass = await runContrast(browser, port);
+      process.exitCode = pass ? 0 : 1;
+    } else if (ALT_CSS[tag]) {
+      await captureAlt(browser, port, tag);
+    } else {
+      console.error('Usage: node demo-polish.recipe.js <before|after|full-deck-before|full-deck-after|contrast|alt-scrim|alt-shadow>');
+      process.exitCode = 2;
+      return;
+    }
+  } finally {
+    await browser.close();
+    await new Promise((resolve) => server.close(resolve));
+  }
+  console.log(`Done: ${tag}. Output in ${OUT_DIR}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tools/capture/loto-player.js
+++ b/tools/capture/loto-player.js
@@ -44,6 +44,16 @@ async function setDarkMode(page, { isPhoneWidth, wantDark }) {
   await btn.click();
 }
 
+// Sets Reviewer/Learner mode by clicking the real #modeToggleBtn wherever
+// it currently lives — same rationale as setDarkMode above.
+async function setReviewerMode(page, { isPhoneWidth, wantReviewer }) {
+  const btn = page.locator('#modeToggleBtn');
+  const pressed = (await btn.getAttribute('aria-pressed')) === 'true';
+  if (pressed === wantReviewer) return;
+  if (isPhoneWidth) await page.locator('#moreBtn').click();
+  await btn.click();
+}
+
 async function openMoreMenu(page) {
   await page.locator('#moreBtn').click();
 }
@@ -56,4 +66,4 @@ async function closeMoreMenu(page) {
   if (isOpen) await page.keyboard.press('Escape');
 }
 
-module.exports = { gotoWaypoint, setDarkMode, openMoreMenu, closeMoreMenu };
+module.exports = { gotoWaypoint, setDarkMode, setReviewerMode, openMoreMenu, closeMoreMenu };


### PR DESCRIPTION
Closes the DEMO-POLISH-2026-07-24 brief (`courses/loto/DEMO-POLISH-2026-07-24.md`).

## Summary
- **Citation chip** (Item 1): `.slide.has-image .citation-chip` gets `position: absolute` back — the scrim-lifting `.slide.has-image > *` rule was dropping it into normal flow on image slides (verified: it was overlapping body text on slide 7, not just "mid-slide"). Fixed rect is pixel-identical to a plain slide's chip at both viewports/modes — see change note. One correction to the brief's own specificity math along the way (inconsequential to the fix itself — see Plan section).
- **Scene-text legibility** (Item 2): scene paragraph + label get the `.definition-box` glass-panel treatment on image slides, replacing sole reliance on the whole-slide radial scrim (weakest exactly at center, where centered text sits). The label needed the panel too — the plan's assumption that it could stay unpaneled (matching `.definition-label`'s precedent) didn't survive a new composite-contrast checker built for this pass: measured 3.12–3.45:1 against the busiest scene slide's actual rendered pixels, below the 4.5:1 floor. Shipped default only — two alternates (localized scrim band, text-shadow) captured for comparison, not shipped.

## New tooling (`tools/capture`)
- `contrast-check.js` — WCAG AA on the rendered composite (worst-case sampled pixel behind the text, not token pairs), per the Slide-Type Standard's explicit requirement. All 8 viewport × mode × element combinations for the shipped scene treatment: PASS.
- `demo-polish.recipe.js` — this pass's capture matrix.
- `setReviewerMode()` added to `loto-player.js` (parallels the existing `setDarkMode()`).

## Regression gates
- **Overflow audit**: 736 checks, field-for-field identical to the #84 baseline on `main` — same two pre-existing clipped-but-scrolling rows, zero new regressions.
- **Full-deck desktop pixel-diff** (184 waypoints — every slide/quiz/close × both modes × all 3 modules): 8 changed, and all 8 are exactly the has-image scene slides this pass touches. Nothing else moved.

Full detail, every judgment call, and the self-check against the brief's P1–P4 are in `courses/loto/CHANGE-NOTE-demo-polish.md`.

## Evidence
All captures + audit JSON on `evidence/demo-polish` (never merged, per the evidence-branch convention — WORKFLOW-TRACE addendum C, T21): https://github.com/sean-roth/sops-nobody-reads/tree/evidence/demo-polish/courses/loto/screenshots/demo-polish

## Commits
1. Plan (committed before any code)
2. Fix + new contrast-check tooling + change note Results/self-check

## Test plan
- [ ] Sean: device-check at `/demo` (Module 1) — citation chip in Reviewer mode, and scene slide 3/29 (the roller-bearing maintenance scene, right after "Tuesday Morning") in both modes
- [ ] Sean: pick the default or an alternate for the scene treatment (or confirm the default) from `evidence/demo-polish`
- [ ] Orchestrator: conformance review
- [ ] Cold auditor: P1–P4 (pre- or post-merge, orchestrator's call)

**Not done by this PR: merge.** Per the seat model, merge is the human/orchestrator gate — this stops at handback.